### PR TITLE
expose .downloaded. closes #38

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,6 +47,7 @@ function Dat (opts) {
   else self._datPath = opts._datPath
   self.live = opts.key ? null : !opts.snapshot
   if (opts.snapshot) self.options.watchFiles = false // Can't watch snapshot files
+  self.downloaded = undefined
 
   self.stats = {
     filesTotal: 0,
@@ -249,6 +250,7 @@ Dat.prototype.download = function (cb) {
       })
     }, function (err) {
       if (err) return cb(err)
+      self.downloaded = true
       return cb(null)
     })
 

--- a/tests/misc.js
+++ b/tests/misc.js
@@ -244,3 +244,30 @@ test('expose stats.peers', function (t) {
     })
   })
 })
+
+test('expose .downloaded', function (t) {
+  rimraf.sync(path.join(shareFolder, '.dat'))
+  var downFolder = path.join(os.tmpdir(), 'dat-' + Math.random().toString(16).slice(2))
+  fs.mkdirSync(downFolder)
+
+  var shareDat = Dat({ dir: shareFolder, snapshot: true, db: memdb() })
+  shareDat.share(function (err) {
+    t.error(err, 'dat shared')
+
+    var downDat = Dat({ dir: downFolder, key: shareDat.key })
+    t.notOk(downDat.downloaded, 'not downloaded')
+
+    downDat.download(function (err) {
+      t.error(err, 'dat downloaded')
+      t.ok(downDat.downloaded, 'dat downloaded')
+
+      downDat.close(function (err) {
+        t.error(err, 'download dat closed')
+        shareDat.close(function (err) {
+          t.error(err, 'share dat closed')
+          t.end()
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
btw we could also do this more elegantly with getters in the future, but for now browser support doesn't allow for this