### PR TITLE
populate key after archive opened

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,8 +83,10 @@ Dat.prototype._open = function (cb) {
         return raf(path.join(self.dir, name))
       }
     })
-    self.key = self.archive.key
-    self.emit('key', self.key)
+    if (!self.options.snapshot) {
+      self.key = self.archive.key
+      self.emit('key', self.key)
+    }
     self._opened = true
     cb()
   })

--- a/index.js
+++ b/index.js
@@ -83,9 +83,14 @@ Dat.prototype._open = function (cb) {
         return raf(path.join(self.dir, name))
       }
     })
-    if (!self.options.snapshot) {
-      self.key = self.archive.key
-      self.emit('key', self.key)
+    if (!self.key) {
+      self.on('key', function (key) {
+        self.key = key
+        self.db.put('!dat!key', key)
+      })
+      if (!self.options.snapshot) {
+        self.emit('key', self.archive.key.toString('hex'))
+      }
     }
     self._opened = true
     cb()
@@ -115,10 +120,7 @@ Dat.prototype.share = function (cb) {
     self.owner = archive.owner
 
     if ((archive.live || archive.owner) && archive.key) {
-      if (!self.key) self.db.put('!dat!key', archive.key.toString('hex'))
       self._joinSwarm()
-      self.key = archive.key
-      self.emit('key', archive.key.toString('hex'))
     }
 
     var importer = self._fileStatus = importFiles(self.archive, self.dir, {
@@ -177,7 +179,6 @@ Dat.prototype.share = function (cb) {
 
       if (self.options.snapshot) {
         self._joinSwarm()
-        self.key = archive.key
         self.emit('key', archive.key.toString('hex'))
       }
 

--- a/index.js
+++ b/index.js
@@ -83,6 +83,8 @@ Dat.prototype._open = function (cb) {
         return raf(path.join(self.dir, name))
       }
     })
+    self.key = self.archive.key
+    self.emit('key', self.key)
     self._opened = true
     cb()
   })

--- a/tests/misc.js
+++ b/tests/misc.js
@@ -52,11 +52,20 @@ test('custom ignore extends default (array)', function (t) {
 test('custom db option', function (t) {
   var dat = Dat({db: memdb(), dir: process.cwd()})
   dat.open(function (err) {
-    t.ok(dat.archive instanceof require('hyperdrive/archive'), 'archive is hyperdrive archive')
-    t.deepEqual(dat.archive.key, dat.key)
     t.error(err)
     t.ok(dat.db.db instanceof require('memdown'), 'db is memdown')
 
+    dat.close(function () {
+      t.end()
+    })
+  })
+})
+
+test('.key on live archive', function (t) {
+  var dat = Dat({db: memdb(), dir: process.cwd()})
+  dat.open(function (err) {
+    t.error(err)
+    t.deepEqual(dat.key, dat.archive.key)
     dat.close(function () {
       t.end()
     })

--- a/tests/misc.js
+++ b/tests/misc.js
@@ -52,6 +52,8 @@ test('custom ignore extends default (array)', function (t) {
 test('custom db option', function (t) {
   var dat = Dat({db: memdb(), dir: process.cwd()})
   dat.open(function (err) {
+    t.ok(dat.archive instanceof require('hyperdrive/archive'), 'archive is hyperdrive archive')
+    t.deepEqual(dat.archive.key, dat.key)
     t.error(err)
     t.ok(dat.db.db instanceof require('memdown'), 'db is memdown')
 

--- a/tests/misc.js
+++ b/tests/misc.js
@@ -65,7 +65,7 @@ test('.key on live archive', function (t) {
   var dat = Dat({db: memdb(), dir: process.cwd()})
   dat.open(function (err) {
     t.error(err)
-    t.deepEqual(dat.key, dat.archive.key)
+    t.deepEqual(dat.key, dat.archive.key.toString('hex'))
     dat.close(function () {
       t.end()
     })


### PR DESCRIPTION
A live archive does not have its key until opened, and this is currently not propagated back to `.key` of the Dat instance.  This breaks desktop archive creation, which does a simple open-then-close to obtain new archive key.  workaround is at https://github.com/datproject/dat-desktop/commit/cfb3d6cb46e3ab9ca27c7021258a4abd454903bb
