### PR TITLE
Multidrive support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- Change types:
   ### Added, ### Changed, ### Fixed, ### Removed, ### Deprecated
 -->
+### Added
+* Support for `opts.drive` and [multidrive](https://github.com/yoshuawuyts/multidrive/)
+* `dat.leaveNetwork` - leave the network for this archive key.
+* Added `dir` option to importer.
+* Made it easier to require Dat as a module, without creating archive.
+
+### Deprecated
+* Expose discovery swarm instance on `dat.network` instead of `dat.network.swarm`.
 
 ## 1.0.0 - 2016-12-21
 * dat-node released with a new API. [Read about changes](https://github.com/datproject/dat-node#moving-from-dat-js) from the old API.

--- a/dat.js
+++ b/dat.js
@@ -60,9 +60,9 @@ Dat.prototype.trackStats = function (opts) {
 }
 
 Dat.prototype.importFiles = function (target, opts, cb) {
-  if (!this.archive.owner) return cb(new Error('Must be archive owner to import files.'))
   if (typeof target !== 'string') return this.importFiles('', target, opts)
   if (typeof opts === 'function') return this.importFiles(target, {}, opts)
+  if (!this.archive.owner) return cb(new Error('Must be archive owner to import files.'))
 
   var self = this
   target = target.length ? target : self.path

--- a/dat.js
+++ b/dat.js
@@ -1,0 +1,117 @@
+var assert = require('assert')
+var path = require('path')
+var multicb = require('multicb')
+var importFiles = require('./lib/import-files')
+var createNetwork = require('./lib/network')
+var stats = require('./lib/stats')
+
+module.exports = Dat
+
+function Dat (archive, db, opts) {
+  if (!(this instanceof Dat)) return new Dat(archive, db, opts)
+  if (typeof opts === 'undefined') return Dat(archive, null, db)
+  assert.ok(archive, 'archive required')
+  // assert.ok(db, 'database required') // maybe not be required for multidrive...
+  assert.ok(opts.dir, 'opts.directory required')
+
+  this.path = path.resolve(opts.dir)
+  this.options = opts
+
+  this.archive = archive
+  this.db = db
+  this.key = archive.key // only resumed/owned archives will have keys here
+  this.live = archive.live
+  this.owner = archive.owner
+  this.resumed = archive.resumed
+}
+
+Dat.prototype.join =
+Dat.prototype.joinNetwork = function (opts) {
+  if (this.network) return this.network.join(this.archive.discoveryKey)
+  var self = this
+
+  var network = self.network = createNetwork(self.archive, opts)
+  self.options.network = network.options
+
+  network.swarm = network // 1.0 backwards compat
+  if (self.owner) return network
+
+  network.once('connection', function () {
+    // automatically open archive and set exposed values
+    self.archive.open(function () {
+      // self.owner = self.archive.owner // For future multi-writer?
+      self.live = self.archive.live
+    })
+  })
+  return network
+}
+
+Dat.prototype.leave =
+Dat.prototype.leaveNetwork = function () {
+  if (!this.network) return
+  this.network.leave(this.archive.discoveryKey)
+}
+
+Dat.prototype.trackStats = function (opts) {
+  opts = opts || {}
+  assert.ok(opts.db || this.db, 'Dat needs database to track stats')
+  this.stats = stats(this.archive, opts.db || this.db)
+  return this.stats
+}
+
+Dat.prototype.importFiles = function (target, opts, cb) {
+  if (!this.archive.owner) return cb(new Error('Must be archive owner to import files.'))
+  if (typeof target !== 'string') return this.importFiles('', target, opts)
+  if (typeof opts === 'function') return this.importFiles(target, {}, opts)
+
+  var self = this
+  target = target.length ? target : self.path
+
+  self.importer = importFiles(self.archive, target, opts, function (err) {
+    if (err || self.archive.live) return cb(err)
+    // Sets self.key for snapshot
+    self.archive.finalize(function (err) {
+      if (err) return cb(err)
+      self.key = self.archive.key
+      // TODO: need to get snapshot key back in db, better way?
+      if (self.db) self.db.put('!dat!key', self.archive.key.toString('hex'), cb)
+    })
+  })
+  self.options.importer = self.importer.options
+  return self.importer
+}
+
+Dat.prototype.close = function (cb) {
+  cb = cb || function () { }
+  var self = this
+  var done = multicb()
+  closeNet(done())
+  closeFileWatch(done())
+  closeArchiveDb(done())
+
+  done(cb)
+
+  function closeArchiveDb (cb) {
+    self.archive.close(function (err) {
+      if (err) return cb(err)
+      if (self.options.db || !self.db) return cb(null)
+      closeDb(cb)
+    })
+  }
+
+  function closeDb (cb) {
+    if (!self.db) return cb()
+    self.db.close(cb)
+  }
+
+  function closeNet (cb) {
+    if (!self.network) return cb()
+    self.network.close(cb)
+  }
+
+  function closeFileWatch (cb) {
+    if (!self.importer) return cb()
+    self.importer.close()
+    cb() // TODO: dat importer close is currently sync-ish
+  }
+}

--- a/dat.js
+++ b/dat.js
@@ -1,6 +1,7 @@
 var assert = require('assert')
 var path = require('path')
 var multicb = require('multicb')
+var encoding = require('dat-encoding')
 var importFiles = require('./lib/import-files')
 var createNetwork = require('./lib/network')
 var stats = require('./lib/stats')
@@ -74,7 +75,7 @@ Dat.prototype.importFiles = function (target, opts, cb) {
       if (err) return cb(err)
       self.key = self.archive.key
       // TODO: need to get snapshot key back in db, better way?
-      if (self.db) self.db.put('!dat!key', self.archive.key.toString('hex'), cb)
+      if (self.db) self.db.put('!dat!key', encoding.str(self.archive.key), cb)
     })
   })
   self.options.importer = self.importer.options

--- a/dat.js
+++ b/dat.js
@@ -75,7 +75,7 @@ Dat.prototype.importFiles = function (target, opts, cb) {
       if (err) return cb(err)
       self.key = self.archive.key
       // TODO: need to get snapshot key back in db, better way?
-      if (self.db) self.db.put('!dat!key', encoding.str(self.archive.key), cb)
+      if (self.db) self.db.put('!dat!key', encoding.toStr(self.archive.key), cb)
     })
   })
   self.options.importer = self.importer.options

--- a/dat.js
+++ b/dat.js
@@ -1,7 +1,6 @@
 var assert = require('assert')
 var path = require('path')
 var multicb = require('multicb')
-var encoding = require('dat-encoding')
 var importFiles = require('./lib/import-files')
 var createNetwork = require('./lib/network')
 var stats = require('./lib/stats')
@@ -89,16 +88,16 @@ Dat.prototype.importFiles = function (target, opts, cb) {
   if (!this.archive.owner) return cb(new Error('Must be archive owner to import files.'))
 
   var self = this
-  target = target.length ? target : self.path
+  target = target && target.length ? target : self.path
+  if (target === self.path && opts.indexing !== false) opts.indexing = true
 
   self.importer = importFiles(self.archive, target, opts, function (err) {
     if (err || self.archive.live) return cb(err)
-    // Sets self.key for snapshot
+    // Finalize snapshot
     self.archive.finalize(function (err) {
       if (err) return cb(err)
-      self.key = self.archive.key
-      // TODO: need to get snapshot key back in db, better way?
-      if (self.db) self.db.put('!dat!key', encoding.toStr(self.archive.key), cb)
+      // TODO: write snapshot key to file
+      cb(null)
     })
   })
   self.options.importer = self.importer.options

--- a/dat.js
+++ b/dat.js
@@ -34,7 +34,7 @@ Dat.prototype.joinNetwork = function (opts) {
   var network = self.network = createNetwork(self.archive, opts)
   self.options.network = network.options
 
-  network.swarm = network // 1.0 backwards compat
+  network.swarm = network // 1.0 backwards compat. TODO: Remove in v2
   if (self.owner) return network
 
   network.once('connection', function () {

--- a/dat.js
+++ b/dat.js
@@ -65,10 +65,7 @@ Dat.prototype.joinNetwork = function (opts) {
 
   network.once('connection', function () {
     // automatically open archive and set exposed values
-    self.archive.open(function () {
-      // self.owner = self.archive.owner // For future multi-writer?
-      self.live = self.archive.live
-    })
+    self.archive.open(noop)
   })
   return network
 }
@@ -109,8 +106,10 @@ Dat.prototype.importFiles = function (target, opts, cb) {
 }
 
 Dat.prototype.close = function (cb) {
-  cb = cb || function () { }
+  cb = cb || noop
   var self = this
+  self.leave()
+
   var done = multicb()
   closeNet(done())
   closeFileWatch(done())
@@ -142,3 +141,5 @@ Dat.prototype.close = function (cb) {
     cb() // TODO: dat importer close is currently sync-ish
   }
 }
+
+function noop () { }

--- a/dat.js
+++ b/dat.js
@@ -20,10 +20,36 @@ function Dat (archive, db, opts) {
 
   this.archive = archive
   this.db = db
-  this.key = archive.key // only resumed/owned archives will have keys here
-  this.live = archive.live
-  this.owner = archive.owner
-  this.resumed = archive.resumed
+
+  var self = this
+
+  // Getters for convenience accessors
+  Object.defineProperties(this, {
+    key: {
+      enumerable: true,
+      get: function () {
+        return self.archive.key
+      }
+    },
+    live: {
+      enumerable: true,
+      get: function () {
+        return self.archive.live
+      }
+    },
+    owner: {
+      enumerable: true,
+      get: function () {
+        return self.archive.owner
+      }
+    },
+    resumed: {
+      enumerable: true,
+      get: function () {
+        return self.archive.resumed
+      }
+    }
+  })
 }
 
 Dat.prototype.join =

--- a/index.js
+++ b/index.js
@@ -1,19 +1,21 @@
 var assert = require('assert')
+var hyperdrive = require('hyperdrive')
 var initArchive = require('./lib/init-archive')
 var Dat = require('./dat')
 
 module.exports = createDat
 
-function createDat (dir, opts, cb) {
-  assert.equal(typeof dir, 'string', 'directory required')
-  if (typeof opts === 'function') return createDat(dir, {}, opts)
+function createDat (dirOrDriveOrDb, opts, cb) {
+  assert.ok(typeof dirOrDriveOrDb, 'directory or drive required')
+  if (typeof opts === 'function') return createDat(dirOrDriveOrDb, {}, opts)
 
-  initArchive(dir, opts, function (err, archive, db) {
+  // Figure out what first arg is
+  if (typeof dirOrDriveOrDb === 'string') opts.dir = dirOrDriveOrDb
+  else if (dirOrDriveOrDb instanceof hyperdrive) opts.drive = dirOrDriveOrDb // TODO: will this fail if our hyperdrive vesrion is different?
+  else opts.db = dirOrDriveOrDb
+
+  initArchive(opts, function (err, archive, db) {
     if (err) return cb(err)
-
-    opts.dir = dir
-    var dat = new Dat(archive, db, opts)
-
-    cb(null, dat)
+    cb(null, new Dat(archive, db, opts))
   })
 }

--- a/index.js
+++ b/index.js
@@ -1,108 +1,19 @@
 var assert = require('assert')
-var path = require('path')
-var multicb = require('multicb')
 var initArchive = require('./lib/init-archive')
-var importFiles = require('./lib/import-files')
-var network = require('./lib/network')
-var stats = require('./lib/stats')
+var Dat = require('./dat')
 
-module.exports = function (dir, opts, cb) {
-  assert.ok(dir, 'directory required')
-  if (typeof opts === 'function') {
-    cb = opts
-    opts = {}
-  }
+module.exports = createDat
 
-  var dat = {
-    path: path.resolve(dir),
-    options: opts
-  }
+function createDat (dir, opts, cb) {
+  assert.equal(typeof dir, 'string', 'directory required')
+  if (typeof opts === 'function') return createDat(dir, {}, opts)
 
   initArchive(dir, opts, function (err, archive, db) {
     if (err) return cb(err)
 
-    dat.archive = archive
-    dat.db = db
-    dat.key = archive.key // only resumed/owned archives will have keys here
-    dat.live = archive.live
-    dat.owner = archive.owner
-    dat.resumed = archive.resumed
-
-    dat.joinNetwork = function (opts) {
-      dat.network = network(archive, opts)
-      dat.options.network = dat.network.options
-      if (dat.owner) return dat.network
-
-      dat.network.swarm.once('connection', function () {
-        // automatically open archive and set exposed values
-        archive.open(function () {
-          // dat.owner = archive.owner // For future multi-writer?
-          dat.live = archive.live
-        })
-      })
-      return dat.network
-    }
-
-    dat.trackStats = function () {
-      dat.stats = stats(archive, db)
-      return dat.stats
-    }
-
-    if (archive.owner) {
-      dat.importFiles = function (opts, cb) {
-        if (typeof opts === 'function') return dat.importFiles({}, opts)
-        if (archive.live) {
-          dat.importer = importFiles(archive, dir, opts, cb)
-        } else {
-          dat.importer = importFiles(archive, dir, opts, function (err) {
-            if (err) return cb(err)
-            // Sets dat.key for snapshot
-            archive.finalize(function (err) {
-              if (err) return cb(err)
-              dat.key = archive.key
-              // TODO: need to get snapshot key back in db, better way?
-              db.put('!dat!key', archive.key.toString('hex'), cb)
-            })
-          })
-        }
-        dat.options.importer = dat.importer.options
-        return dat.importer
-      }
-    }
-
-    dat.close = function (cb) {
-      var done = multicb()
-      closeNet(done())
-      closeFileWatch(done())
-      closeArchiveDb(done())
-
-      done(cb)
-    }
+    opts.dir = dir
+    var dat = new Dat(archive, db, opts)
 
     cb(null, dat)
-
-    function closeArchiveDb (cb) {
-      dat.archive.close(function (err) {
-        if (err) return cb(err)
-        if (opts.db || !dat.db) return cb(null)
-        closeDb(cb)
-      })
-    }
-
-    function closeDb (cb) {
-      if (!dat.db) return cb()
-      dat.db.close(cb)
-    }
-
-    function closeNet (cb) {
-      if (!dat.network) return cb()
-      dat.network.swarm.close(cb)
-    }
-
-    function closeFileWatch (cb) {
-      if (!dat.importer) return cb()
-      dat.importer.close()
-      cb() // TODO: dat importer close is currently sync-ish
-    }
   })
 }

--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@ var assert = require('assert')
 var hyperdrive = require('hyperdrive')
 var path = require('path')
 var untildify = require('untildify')
-var multicb = require('multicb')
 var debug = require('debug')('dat-node')
 var initArchive = require('./lib/init-archive')
 var Dat = require('./dat')
@@ -20,7 +19,7 @@ function createDat (dirOrDrive, opts, cb) {
 
   if (!opts.dir && opts.drive.location) opts.dir = opts.drive.location // TODO: I think this is just a multidrive thing
   else if (!opts.dir) return cb(new Error('opts.dir must be specified'))
-  
+
   opts.dir = path.resolve(untildify(opts.dir))
 
   debug('Running initArchive on', opts.dir, 'with opts:', opts)

--- a/index.js
+++ b/index.js
@@ -5,14 +5,17 @@ var Dat = require('./dat')
 
 module.exports = createDat
 
-function createDat (dirOrDriveOrDb, opts, cb) {
-  assert.ok(typeof dirOrDriveOrDb, 'directory or drive required')
-  if (typeof opts === 'function') return createDat(dirOrDriveOrDb, {}, opts)
+function createDat (dirOrDrive, opts, cb) {
+  assert.ok(dirOrDrive, 'directory or drive required')
+  if (typeof opts === 'function') return createDat(dirOrDrive, {}, opts)
 
   // Figure out what first arg is
-  if (typeof dirOrDriveOrDb === 'string') opts.dir = dirOrDriveOrDb
-  else if (dirOrDriveOrDb instanceof hyperdrive) opts.drive = dirOrDriveOrDb // TODO: will this fail if our hyperdrive vesrion is different?
-  else opts.db = dirOrDriveOrDb
+  if (typeof dirOrDrive === 'string') opts.dir = dirOrDrive
+  else if (dirOrDrive instanceof hyperdrive) opts.drive = dirOrDrive // TODO: will this fail if our hyperdrive vesrion is different?
+  else return cb(new Error('first argument must either be a directory or hyperdrive instance'))
+
+  if (drive.location && !opts.dir) opts.dir = drive.location // TODO: I think this is just a multidrive thing
+  else if (!opts.dir) return cb(new Error('opts.dir must be specified'))
 
   initArchive(opts, function (err, archive, db) {
     if (err) return cb(err)

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ function createDat (dirOrDrive, opts, cb) {
   else if (dirOrDrive instanceof hyperdrive) opts.drive = dirOrDrive // TODO: will this fail if our hyperdrive vesrion is different?
   else return cb(new Error('first argument must either be a directory or hyperdrive instance'))
 
-  if (drive.location && !opts.dir) opts.dir = drive.location // TODO: I think this is just a multidrive thing
+  if (!opts.dir && opts.drive.location) opts.dir = opts.drive.location // TODO: I think this is just a multidrive thing
   else if (!opts.dir) return cb(new Error('opts.dir must be specified'))
 
   initArchive(opts, function (err, archive, db) {

--- a/index.js
+++ b/index.js
@@ -17,7 +17,8 @@ function createDat (dirOrDrive, opts, cb) {
   else if (dirOrDrive instanceof hyperdrive) opts.drive = dirOrDrive // TODO: will this fail if our hyperdrive vesrion is different?
   else return cb(new Error('first argument must either be a directory or hyperdrive instance'))
 
-  if (!opts.dir && opts.drive.location) opts.dir = opts.drive.location // TODO: I think this is just a multidrive thing
+  // TODO: this is a multidrive thing, make it part of this API?
+  if (!opts.dir && opts.drive.location) opts.dir = opts.drive.location
   else if (!opts.dir) return cb(new Error('opts.dir must be specified'))
 
   opts.dir = path.resolve(untildify(opts.dir))
@@ -26,6 +27,7 @@ function createDat (dirOrDrive, opts, cb) {
   initArchive(opts, function (err, archive, db) {
     if (err) return cb(err)
     debug('initArchive callback')
-    cb(null, new Dat(archive, db, opts))
+    var dat = new Dat(archive, db, opts)
+    cb(null, dat)
   })
 }

--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ function createDat (dirOrDrive, opts, cb) {
   debug('Running initArchive on', opts.dir, 'with opts:', opts)
   initArchive(opts, function (err, archive, db) {
     if (err) return cb(err)
+    debug('initArchive callback')
     cb(null, new Dat(archive, db, opts))
   })
 }

--- a/lib/import-files.js
+++ b/lib/import-files.js
@@ -5,7 +5,6 @@ var walker = require('folder-walker')
 var hyperImport = require('hyperdrive-import-files')
 var debug = require('debug')('dat-node')
 
-
 module.exports = importer
 
 function importer (archive, target, opts, cb) {
@@ -37,7 +36,7 @@ function importer (archive, target, opts, cb) {
 
   debug('Importer created. Counting Files.')
   // Start counting the files
-  each(walker(dir), countFiles, function (err) {
+  each(walker(target), countFiles, function (err) {
     if (err) cb(err)
     debug('File count finished')
     importer.emit('count finished', countStats)

--- a/lib/import-files.js
+++ b/lib/import-files.js
@@ -28,8 +28,6 @@ function importer (archive, target, opts, cb) {
   else if (Array.isArray(opts.ignore)) opts.ignore = opts.ignore.concat(defaultIgnore)
   else opts.ignore = [opts.ignore].concat(defaultIgnore)
 
-  if (opts.indexing !== false) opts.indexing = true
-
   var importer = hyperImport(archive, target, opts, cb)
 
   importer.options = importer.options || opts

--- a/lib/import-files.js
+++ b/lib/import-files.js
@@ -1,9 +1,9 @@
 var assert = require('assert')
 var countImport = require('hyperdrive-count-import')
 
-module.exports = function (archive, dir, opts, cb) {
+module.exports = function (archive, target, opts, cb) {
   assert.ok(archive, 'lib/import-files archive required')
-  assert.ok(dir, 'lib/import-files directory required')
+  assert.ok(target, 'lib/import-files target directory required')
   opts = opts || {}
   if (typeof opts === 'function') {
     cb = opts
@@ -17,7 +17,7 @@ module.exports = function (archive, dir, opts, cb) {
   else if (Array.isArray(opts.ignore)) opts.ignore = opts.ignore.concat(defaultIgnore)
   else opts.ignore = [opts.ignore].concat(defaultIgnore)
 
-  var importer = countImport(archive, dir, opts, cb)
+  var importer = countImport(archive, target, opts, cb)
   importer.options = importer.options || opts
   return importer
 }

--- a/lib/init-archive.js
+++ b/lib/init-archive.js
@@ -43,7 +43,7 @@ module.exports = function (opts, cb) {
       if (vals.length > 2 && !opts.key) return cb('Drive has multiple archives. Must specify key.')
       else if (!vals.length || opts.key) {
         archive = drive.createArchive(opts.key, opts)
-        return doneArchive(false)
+        return doneArchive(!vals.length) // do not open if new drive
       }
       debug(`Drive has ${vals.length} existing keys. Getting archive key.`)
 
@@ -67,11 +67,11 @@ module.exports = function (opts, cb) {
     })
   }
 
-  function doneArchive (doOpen) {
+  function doneArchive (doNotOpen) {
     debug('Archive created')
-    // doOpen = false if no existing feeds in drive
+    // doNotOpen = true if no existing feeds in drive
     // Opening would have to wait for swarm connection
-    if (doOpen === false) return cb(null, archive, db)
+    if (doNotOpen) return cb(null, archive, db)
 
     archive.resumed = true
 

--- a/lib/init-archive.js
+++ b/lib/init-archive.js
@@ -1,16 +1,17 @@
 var assert = require('assert')
 var path = require('path')
-var driveOrCore = require('drive-or-core')
 var level = require('level')
 var hyperdrive = require('hyperdrive')
 var raf = require('random-access-file')
 var debug = require('debug')('dat-node')
+// var driveOrCore = require('drive-or-core')
 
 module.exports = function (opts, cb) {
   assert.ok(opts, 'lib/init-archive opts required')
   assert.ok(opts.dir || opts.drive || opts.db, 'dir, drive, or db option required')
   assert.ok(typeof cb === 'function', 'lib/init-archive callback function required')
 
+  var archive
   var drive
   var db
 
@@ -36,34 +37,41 @@ module.exports = function (opts, cb) {
   })
 
   function checkDriveKeys () {
+    debug('Reading existing keys in drive')
     drive.core.list(function (err, vals) {
       if (err) return cb(err)
       if (vals.length > 2 && !opts.key) return cb('Drive has multiple archives. Must specify key.')
-      if (!vals.length || opts.key) {
-        var archive = drive.createArchive(opts.key, opts)
-        return doneArchive(archive, false)
+      else if (!vals.length || opts.key) {
+        archive = drive.createArchive(opts.key, opts)
+        return doneArchive(false)
       }
+      debug(`Drive has ${vals.length} existing keys. Getting archive key.`)
 
-      // Two keys, figure out which is metadata
-      var feed1 = drive.core.createFeed(vals[0], opts)
-      var feed2 = drive.core.createFeed(vals[1], opts)
-      driveOrCore(feed1, feed2, function (err, type, key) {
-        if (err) return cb(err)
-        if (type === 'feed') return cb('Existing archive not found in drive.') // TODO: create new archive?
+      debug('Making archive with existing key', vals[0].toString('hex'))
+      archive = drive.createArchive(vals[0], opts)
+      doneArchive()
 
-        var archiveOpts = Object.assign({}, opts)
-        archiveOpts.metadata = (key === feed1.key) ? feed1 : feed2 // if true => feed1 is metadata
-        archiveOpts.content = (key === feed2.key) ? feed1 : feed2 // if true => feed2 is metadata
-        var archive = drive.createArchive(archiveOpts)
-        doneArchive(archive)
-      })
+      // TODO: if we can't assume first key is metadata
+      // // Two keys, figure out which is metadata
+      // var feed1 = drive.core.createFeed(vals[0], opts)
+      // var feed2 = drive.core.createFeed(vals[1], opts)
+      // debug('Checking feeds to find metadata')
+      // driveOrCore(feed1, feed2, function (err, type, key) {
+      //   if (err) return cb(err)
+      //   if (type === 'feed') return cb('Existing archive not found in drive.') // TODO: create new archive?
+
+      //   var archiveOpts = Object.assign({}, opts)
+      //   archiveOpts.metadata = (key === feed1.key) ? feed1 : feed2 // if true => feed1 is metadata
+      //   archiveOpts.content = (key === feed2.key) ? feed1 : feed2 // if true => feed2 is metadata
+      // })
     })
   }
 
-  function doneArchive (archive, doOpen) {
+  function doneArchive (doOpen) {
+    debug('Archive created')
     // doOpen = false if no existing feeds in drive
     // Opening would have to wait for swarm connection
-    if (!doOpen) return cb(null, archive, db)
+    if (doOpen === false) return cb(null, archive, db)
 
     archive.resumed = true
 

--- a/lib/init-archive.js
+++ b/lib/init-archive.js
@@ -47,22 +47,31 @@ module.exports = function (opts, cb) {
       }
       debug(`Drive has ${vals.length} existing keys. Getting archive key.`)
 
-      debug('Making archive with existing key', vals[0].toString('hex'))
-      archive = drive.createArchive(vals[0], opts)
-      doneArchive()
+      // TODO: I think vals[1] will always be metadata. But what if it's not?
+      debug('Making archive with key', vals[1].toString('hex'))
+      archive = drive.createArchive(vals[1], opts)
+      archive.open(function (err) {
+        if (err && err.message.indexOf('Unknown message type') === -1) return cb(err)
+        if (!err) return doneArchive()
+        archive = drive.createArchive(vals[0], opts)
+        doneArchive()
+      })
 
-      // TODO: if we can't assume first key is metadata
-      // // Two keys, figure out which is metadata
+      // TODO: another implementation with strict checking of feeds
+      // Two keys, figure out which is metadata
       // var feed1 = drive.core.createFeed(vals[0], opts)
       // var feed2 = drive.core.createFeed(vals[1], opts)
-      // debug('Checking feeds to find metadata')
+      // debug('Checking feeds to find metadata', feed1.key.toString('hex'), feed2.key.toString('hex'))
       // driveOrCore(feed1, feed2, function (err, type, key) {
       //   if (err) return cb(err)
+      //   debug('type', type, 'key', key)
       //   if (type === 'feed') return cb('Existing archive not found in drive.') // TODO: create new archive?
 
       //   var archiveOpts = Object.assign({}, opts)
       //   archiveOpts.metadata = (key === feed1.key) ? feed1 : feed2 // if true => feed1 is metadata
       //   archiveOpts.content = (key === feed2.key) ? feed1 : feed2 // if true => feed2 is metadata
+      //   archive = drive.createArchive(key, archiveOpts)
+      //   doneArchive()
       // })
     })
   }
@@ -75,10 +84,10 @@ module.exports = function (opts, cb) {
 
     archive.resumed = true
 
-    debug('Opening archive')
+    debug('Opening archive', archive.key.toString('hex'))
     archive.open(function (err) {
-      debug('Archive opened')
       if (err) return cb(err)
+      debug('Archive opened')
       cb(null, archive, db)
     })
   }

--- a/lib/init-archive.js
+++ b/lib/init-archive.js
@@ -9,9 +9,8 @@ module.exports = function (dir, opts, cb) {
   assert.ok(opts, 'lib/init-archive opts required')
   assert.ok(typeof cb === 'function', 'lib/init-archive callback function required')
 
-  if (opts.db) {
-    // TODO: this won't be compatible with CLI. need to do drive in folderarhicve
-    var drive = hyperdrive(opts.db)
+  if (opts.db || opts.drive) {
+    var drive = opts.drive || hyperdrive(opts.db)
     if (!opts.file) {
       opts.file = function (name) {
         return raf(path.join(dir, name))

--- a/lib/init-archive.js
+++ b/lib/init-archive.js
@@ -1,38 +1,72 @@
 var assert = require('assert')
 var path = require('path')
+var driveOrCore = require('drive-or-core')
+var level = require('level')
 var hyperdrive = require('hyperdrive')
 var raf = require('random-access-file')
-var folderArchive = require('dat-folder-archive')
 
-module.exports = function (dir, opts, cb) {
-  assert.ok(dir, 'lib/init-archive directory required')
+module.exports = function (opts, cb) {
   assert.ok(opts, 'lib/init-archive opts required')
+  assert.ok(opts.dir || opts.drive || opts.db, 'dir, drive, or db option required')
   assert.ok(typeof cb === 'function', 'lib/init-archive callback function required')
 
+  var drive
+  var db
+
   if (opts.db || opts.drive) {
-    var drive = opts.drive || hyperdrive(opts.db)
+    drive = opts.drive || hyperdrive(opts.db)
     if (!opts.file) {
       opts.file = function (name) {
-        return raf(path.join(dir, name))
+        return raf(path.join(opts.dir, name))
       }
     }
-    var archive = drive.createArchive(opts.key, opts)
-    var db = opts.db ? opts.db : drive.core._db
-    return cb(null, archive, db)
+    db = opts.db ? opts.db : drive.core._db
+    return checkDriveKeys()
   }
 
-  folderArchive(dir, opts, function (err, archive, db) {
-    if (err) return cb(err)
+  var dbPath = path.join(opts.dir, '.dat')
 
-    if (opts.key) {
-      // Downloading an archive (archive.open not reliable)
-      // TODO: better way to handle open for resume?
-      if (!archive.owner) archive.owner = false // TODO: HACK!
-      return cb(null, archive, db)
-    }
+  level(dbPath, function (err, _db) {
+    if (err) return cb(err)
+    db = _db
+    drive = hyperdrive(db)
+    checkDriveKeys()
+  })
+
+  function checkDriveKeys () {
+    drive.core.list(function (err, vals) {
+      if (err) return cb(err)
+      if (vals.length > 2 && !opts.key) return cb('Drive has multiple archives. Must specify key.')
+      if (!vals.length || opts.key) {
+        var archive = drive.createArchive(opts.key, opts)
+        return doneArchive(archive, false)
+      }
+
+      // Two keys, figure out which is metadata
+      var feed1 = drive.core.createFeed(vals[0], opts)
+      var feed2 = drive.core.createFeed(vals[1], opts)
+      driveOrCore(feed1, feed2, function (err, type, key) {
+        if (err) return cb(err)
+        if (type === 'feed') return cb('Existing archive not found in drive.') // TODO: create new archive?
+
+        var archiveOpts = Object.assign({}, opts)
+        archiveOpts.metadata = (key === feed1.key) ? feed1 : feed2 // if true => feed1 is metadata
+        archiveOpts.content = (key === feed2.key) ? feed1 : feed2 // if true => feed2 is metadata
+        var archive = drive.createArchive(archiveOpts)
+        doneArchive(archive)
+      })
+    })
+  }
+
+  function doneArchive (archive, doOpen) {
+    // doOpen = false if no existing feeds in drive
+    // Opening would have to wait for swarm connection
+    if (!doOpen) return cb(null, archive, db)
+
+    archive.resumed = true
     archive.open(function (err) {
       if (err) return cb(err)
       cb(null, archive, db)
     })
-  })
+  }
 }

--- a/lib/init-archive.js
+++ b/lib/init-archive.js
@@ -9,18 +9,14 @@ module.exports = function (dir, opts, cb) {
   assert.ok(opts, 'lib/init-archive opts required')
   assert.ok(typeof cb === 'function', 'lib/init-archive callback function required')
 
-  if (opts.db) {
-    var drive = hyperdrive(opts.db)
+  if (opts.db || opts.drive) {
+    var drive = opts.drive || hyperdrive(opts.db)
     if (!opts.file) {
       opts.file = function (name) {
         return raf(path.join(dir, name))
       }
     }
-    var archive = drive.createArchive(opts.key, {
-      file: opts.file,
-      live: opts.live,
-      sparse: opts.sparse
-    })
+    var archive = drive.createArchive(opts.key, opts)
     return cb(null, archive, opts.db)
   }
 

--- a/lib/init-archive.js
+++ b/lib/init-archive.js
@@ -9,8 +9,9 @@ module.exports = function (dir, opts, cb) {
   assert.ok(opts, 'lib/init-archive opts required')
   assert.ok(typeof cb === 'function', 'lib/init-archive callback function required')
 
-  if (opts.db || opts.drive) {
-    var drive = opts.drive || hyperdrive(opts.db)
+  if (opts.db) {
+    // TODO: this won't be compatible with CLI. need to do drive in folderarhicve
+    var drive = hyperdrive(opts.db)
     if (!opts.file) {
       opts.file = function (name) {
         return raf(path.join(dir, name))

--- a/lib/init-archive.js
+++ b/lib/init-archive.js
@@ -17,7 +17,8 @@ module.exports = function (dir, opts, cb) {
       }
     }
     var archive = drive.createArchive(opts.key, opts)
-    return cb(null, archive, opts.db)
+    var db = opts.db ? opts.db : drive.core._db
+    return cb(null, archive, db)
   }
 
   folderArchive(dir, opts, function (err, archive, db) {

--- a/lib/init-archive.js
+++ b/lib/init-archive.js
@@ -5,29 +5,29 @@ var hyperdrive = require('hyperdrive')
 var raf = require('random-access-file')
 var encoding = require('dat-encoding')
 var debug = require('debug')('dat-node')
-// var driveOrCore = require('drive-or-core')
 
 module.exports = function (opts, cb) {
   assert.ok(opts, 'lib/init-archive opts required')
-  assert.ok(opts.dir || opts.drive || opts.db, 'dir, drive, or db option required')
+  assert.ok(opts.dir, 'dir option required')
   assert.ok(typeof cb === 'function', 'lib/init-archive callback function required')
 
   var archive
   var drive
   var db
+  var dbPath = opts.dbPath || path.join(opts.dir, '.dat')
+
+  if (!opts.file) {
+    // TODO: do we always want this set?
+    opts.file = function (name) {
+      return raf(path.join(opts.dir, name))
+    }
+  }
 
   if (opts.db || opts.drive) {
     drive = opts.drive || hyperdrive(opts.db)
-    if (!opts.file) {
-      opts.file = function (name) {
-        return raf(path.join(opts.dir, name))
-      }
-    }
     db = opts.db ? opts.db : drive.core._db
     return checkDriveKeys()
   }
-
-  var dbPath = path.join(opts.dir, '.dat')
 
   debug('Making/Reading archive database')
   level(dbPath, function (err, _db) {
@@ -38,45 +38,31 @@ module.exports = function (opts, cb) {
   })
 
   function checkDriveKeys () {
+    // Try to resume archives if there are keys in the drive
     debug('Reading existing keys in drive')
     drive.core.list(function (err, vals) {
       if (err) return cb(err)
       if (vals.length > 2 && !opts.key) return cb('Drive has multiple archives. Must specify key.')
       else if (!vals.length || opts.key) {
+        if (!vals.length) debug('No existing feeds in drive')
+        if (opts.key) debug('Resuming using key option', opts.key)
         if (opts.key && typeof opts.key === 'string') opts.key = encoding.toBuf(opts.key)
         archive = drive.createArchive(opts.key, opts)
         return doneArchive(!vals.length) // do not open if new drive
       }
       debug(`Drive has ${vals.length} existing keys. Getting archive key.`)
 
-      // TODO: try to guess metadata and fail?
-      debug('Making archive with key', vals[vals.length-1].toString('hex'))
-      archive = drive.createArchive(vals[vals.length-1], opts)
+      // Try to guess metadata and maybe fail
+      debug('Making archive with key', vals[vals.length - 1].toString('hex'))
+      archive = drive.createArchive(vals[vals.length - 1], opts)
       archive.open(function (err) {
-        var badKey = err && err.message.indexOf('Unknown message type') > -1
-        if (err & !badKey) return cb(err)
         if (!err) return doneArchive()
+        var badKey = err && (err.message.indexOf('Unknown message type') > -1 || err.message.indexOf('Key not found in database') > -1)
+        if (err & !badKey) return cb(err)
+        debug('Bad Key. Trying other key.')
         archive = drive.createArchive(vals[0], opts)
         doneArchive()
       })
-
-      // TODO: another implementation with strict checking of feeds
-      // Two keys, figure out which is metadata
-      // TODO: https://github.com/mafintosh/hypercore/issues/62
-      // var feed1 = drive.core.createFeed(vals[1], opts)
-      // var feed2 = drive.core.createFeed(vals[0], opts)
-      // debug('Checking feeds to find metadata', feed1.key.toString('hex'), feed2.key.toString('hex'))
-      // driveOrCore(feed1, feed2, function (err, type, key) {
-      //   if (err) return cb(err)
-      //   debug('type', type, 'key', key)
-      //   if (type === 'feed') return cb('Existing archive not found in drive.') // TODO: create new archive?
-
-      //   var archiveOpts = Object.assign({}, opts)
-      //   archiveOpts.metadata = (key === feed1.key) ? feed1 : feed2 // if true => feed1 is metadata
-      //   archiveOpts.content = (key === feed2.key) ? feed1 : feed2 // if true => feed2 is metadata
-      //   archive = drive.createArchive(key, archiveOpts)
-      //   doneArchive()
-      // })
     })
   }
 

--- a/lib/init-archive.js
+++ b/lib/init-archive.js
@@ -3,6 +3,7 @@ var path = require('path')
 var level = require('level')
 var hyperdrive = require('hyperdrive')
 var raf = require('random-access-file')
+var encoding = require('dat-encoding')
 var debug = require('debug')('dat-node')
 // var driveOrCore = require('drive-or-core')
 
@@ -42,16 +43,18 @@ module.exports = function (opts, cb) {
       if (err) return cb(err)
       if (vals.length > 2 && !opts.key) return cb('Drive has multiple archives. Must specify key.')
       else if (!vals.length || opts.key) {
+        if (opts.key && typeof opts.key === 'string') opts.key = encoding.toBuf(opts.key)
         archive = drive.createArchive(opts.key, opts)
         return doneArchive(!vals.length) // do not open if new drive
       }
       debug(`Drive has ${vals.length} existing keys. Getting archive key.`)
 
-      // TODO: I think vals[1] will always be metadata. But what if it's not?
-      debug('Making archive with key', vals[1].toString('hex'))
-      archive = drive.createArchive(vals[1], opts)
+      // TODO: try to guess metadata and fail?
+      debug('Making archive with key', vals[vals.length-1].toString('hex'))
+      archive = drive.createArchive(vals[vals.length-1], opts)
       archive.open(function (err) {
-        if (err && err.message.indexOf('Unknown message type') === -1) return cb(err)
+        var badKey = err && err.message.indexOf('Unknown message type') > -1
+        if (err & !badKey) return cb(err)
         if (!err) return doneArchive()
         archive = drive.createArchive(vals[0], opts)
         doneArchive()
@@ -59,8 +62,9 @@ module.exports = function (opts, cb) {
 
       // TODO: another implementation with strict checking of feeds
       // Two keys, figure out which is metadata
-      // var feed1 = drive.core.createFeed(vals[0], opts)
-      // var feed2 = drive.core.createFeed(vals[1], opts)
+      // TODO: https://github.com/mafintosh/hypercore/issues/62
+      // var feed1 = drive.core.createFeed(vals[1], opts)
+      // var feed2 = drive.core.createFeed(vals[0], opts)
       // debug('Checking feeds to find metadata', feed1.key.toString('hex'), feed2.key.toString('hex'))
       // driveOrCore(feed1, feed2, function (err, type, key) {
       //   if (err) return cb(err)

--- a/lib/network.js
+++ b/lib/network.js
@@ -6,6 +6,6 @@ module.exports = function (archive, opts) {
   opts = opts || {}
 
   var swarm = hyperdiscovery(archive, opts)
-  swarm.options = swarm.options || opts
+  swarm.options = swarm._options
   return swarm
 }

--- a/lib/network.js
+++ b/lib/network.js
@@ -6,14 +6,6 @@ module.exports = function (archive, opts) {
   opts = opts || {}
 
   var swarm = hyperdiscovery(archive, opts)
-  var network = {
-    swarm: swarm,
-    options: swarm.options || opts
-  }
-
-  network.__defineGetter__('connected', function () {
-    return swarm.connected
-  })
-
-  return network
+  swarm.options = swarm.options || opts
+  return swarm
 }

--- a/lib/stats.js
+++ b/lib/stats.js
@@ -12,7 +12,7 @@ module.exports = function (archive, db) {
     archive: archive,
     db: sub(db, `${encoding.toStr(archive.key)}-stats`)
   })
-  stats.network = networkSpeed(archive, {timeout: 1000})
+  stats.network = networkSpeed(archive, {timeout: 2000})
 
   return stats
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "license": "MIT",
   "dependencies": {
     "dat-encoding": "^4.0.1",
+    "drive-or-core": "^1.0.0",
     "hyperdiscovery": "^1.0.1",
     "hyperdrive": "^7.9.0",
     "hyperdrive-count-import": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   "dependencies": {
     "anymatch": "^1.3.0",
     "dat-encoding": "^4.0.1",
-    "drive-or-core": "^1.0.0",
     "debug": "^2.6.0",
     "folder-walker": "^3.0.0",
     "hyperdiscovery": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -18,12 +18,12 @@
   "license": "MIT",
   "dependencies": {
     "dat-encoding": "^4.0.1",
-    "dat-folder-archive": "^1.1.1",
     "hyperdiscovery": "^1.0.1",
     "hyperdrive": "^7.9.0",
     "hyperdrive-count-import": "^1.0.0",
     "hyperdrive-network-speed": "^1.0.1",
     "hyperdrive-stats": "^3.0.0",
+    "level": "^1.5.0",
     "multicb": "^1.2.1",
     "random-access-file": "^1.3.1",
     "subleveldown": "^2.1.0"

--- a/readme.md
+++ b/readme.md
@@ -47,7 +47,6 @@ Create a Dat archive on the file system inside `dir`:
 ```js
 var Dat = require('dat-node')
 
-// dat-node always takes `dir` as the first argument
 Dat(dir, function (err, dat) {
   console.log(dat.path) // dat is created here with a .dat folder
 
@@ -85,7 +84,6 @@ Downloading a Dat archive is similar, but you also have to pass `{key: <download
 ```js
 var Dat = require('dat-node')
 
-// dat-node always takes `dir` as the first argument
 Dat(dir, {key: 'download-key'}, function (err, dat) {
   // Join the network
   var network = dat.joinNetwork(opts)
@@ -107,18 +105,15 @@ Dat-node uses hyperdrive stats to track how much has been downloaded so you can 
 
 ## API
 
-### `Dat(dir, [opts], cb)``
+### `Dat(dir|drive|db, [opts], cb)``
 
-Initialize a Dat Archive in `dir`. If there is an existing Dat Archive, the archive will be resumed.
+Initialize a Dat Archive in `dir`. If there is an existing Dat Archive, the archive will be resumed. You can also pass a `hyperdrive` instance or a level-compatible `database`.
 
 Most options are passed directly to the module you're using (e.g. `dat.importFiles(opts)`. However, there are also some initial `opts` can include:
 
 ```js
 opts = {
-  db: level('dir/.dat'), // level-db compatible database
-  drive: hyperdrive(db), // an external hyperdrive instance.
   key: '<dat-key>', // existing key to create archive with or resume
-  resume: Boolean, // fail if existing archive differs from opts.key
 
   // Hyperdrive createArchive options
   live: Boolean, // archive.live setting (only set if archive is owned)

--- a/tests/download.js
+++ b/tests/download.js
@@ -154,6 +154,7 @@ test('download from snapshot', function (t) {
     t.error(err, 'live: false share, no error')
     shareDat = dat
     dat.importFiles(function (err) {
+      t.error(err, 'import no error')
       shareKey = dat.archive.key
       dat.joinNetwork()
       download()

--- a/tests/download.js
+++ b/tests/download.js
@@ -61,7 +61,7 @@ test('Download with default opts', function (t) {
     })
 
     var network = dat.joinNetwork()
-    network.swarm.once('connection', function () {
+    network.once('connection', function () {
       t.pass('connects via network')
     })
 

--- a/tests/download.js
+++ b/tests/download.js
@@ -153,12 +153,10 @@ test('download from snapshot', function (t) {
   Dat(fixtures, {live: false}, function (err, dat) {
     t.error(err, 'live: false share, no error')
     shareDat = dat
-    dat.importFiles(function () {
-      dat.archive.finalize(function () {
-        shareKey = dat.archive.key
-        dat.joinNetwork()
-        download()
-      })
+    dat.importFiles(function (err) {
+      shareKey = dat.archive.key
+      dat.joinNetwork()
+      download()
     })
   })
 

--- a/tests/download.js
+++ b/tests/download.js
@@ -51,7 +51,7 @@ test('Download with default opts', function (t) {
       // Network needs to connect for archive.open to callback
       archive.content.once('download-finished', function () {
         t.pass('archive.content emits download-finished')
-        done()
+        setTimeout(done, 500) // issue w/ download-finished firing before stats updated
       })
     })
 

--- a/tests/misc.js
+++ b/tests/misc.js
@@ -3,6 +3,7 @@ var test = require('tape')
 var anymatch = require('anymatch')
 var rimraf = require('rimraf')
 var memdb = require('memdb')
+var memdown = require('memdown')
 var hyperdrive = require('hyperdrive')
 var encoding = require('dat-encoding')
 var fs = require('fs')
@@ -113,7 +114,7 @@ test('custom drive option', function (t) {
     t.error(err)
     dat.archive.open(function () {
       // Need open otherwise get DeferredLevelDOWN
-      t.ok(dat.db.db instanceof require('memdown'), 'db is memdown')
+      t.ok(dat.db.db instanceof memdown, 'db is memdown')
       try {
         fs.statSync(path.join(shareFolder, '.dat'))
         t.fail('.dat folder exists =(')

--- a/tests/misc.js
+++ b/tests/misc.js
@@ -225,7 +225,7 @@ test('expose swarm.connected', function (t) {
     var network = shareDat.joinNetwork()
     t.equal(network.connected, 0, '0 peers')
 
-    network.swarm.once('connection', function () {
+    network.once('connection', function () {
       t.ok(network.connected >= 1, '>=1 peer')
 
       downDat.close(function (err) {

--- a/tests/misc.js
+++ b/tests/misc.js
@@ -3,6 +3,7 @@ var test = require('tape')
 var anymatch = require('anymatch')
 var rimraf = require('rimraf')
 var memdb = require('memdb')
+var hyperdrive = require('hyperdrive')
 var encoding = require('dat-encoding')
 var fs = require('fs')
 var os = require('os')
@@ -88,6 +89,27 @@ test('ignore hidden option turned off', function (t) {
 test('custom db option', function (t) {
   rimraf.sync(path.join(shareFolder, '.dat'))
   Dat(shareFolder, {db: memdb()}, function (err, dat) {
+    t.error(err)
+    dat.archive.open(function () {
+      // Need open otherwise get DeferredLevelDOWN
+      t.ok(dat.db.db instanceof require('memdown'), 'db is memdown')
+      try {
+        fs.statSync(path.join(shareFolder, '.dat'))
+        t.fail('.dat folder exists =(')
+      } catch (e) {
+        t.pass('.dat folder does not exist')
+      }
+      dat.close(function () {
+        t.end()
+      })
+    })
+  })
+})
+
+test('custom drive option', function (t) {
+  rimraf.sync(path.join(shareFolder, '.dat'))
+  var drive = hyperdrive(memdb())
+  Dat(shareFolder, {drive: drive}, function (err, dat) {
     t.error(err)
     dat.archive.open(function () {
       // Need open otherwise get DeferredLevelDOWN

--- a/tests/share.js
+++ b/tests/share.js
@@ -45,7 +45,7 @@ test('create dat with default ops', function (t) {
         t.pass('stats update triggers')
       })
 
-      network.swarm.once('listening', function () {
+      network.once('listening', function () {
         t.pass('network listening')
       })
 


### PR DESCRIPTION
I think I finished this before the break but need to check it over. ~Depends on https://github.com/joehand/dat-folder-archive/pull/2.~ (Implemented this directly in here instead of in dat-folder-archive).

I changed the API slightly around the network to make it easier to use an external swarm module. But everything is still backwards compatible.

## TODO

* Not doing: ~Release MD support in dat-folder-archiver~
* Done: ~Add MD test here~
* Done: ~pfrazee: updating the usage to simplify it, so you can just do `Dat(drive, function(err, dat) {}`~
* [Done](https://github.com/datproject/dat-node/pull/65#issuecomment-272560931)  ~Ensure compatibility with dat cli (to do this we need to put the archive key into the `.dat` db)~
- [x] Review & update docs
- [x] Check compatibility with dat-next, old CLI.
- [x] Merge!

