### PR TITLE
Fixing bugs for dat-next

### DIFF
--- a/dat.js
+++ b/dat.js
@@ -112,9 +112,12 @@ Dat.prototype.close = function (cb) {
   var done = multicb()
   closeNet(done())
   closeFileWatch(done())
-  closeArchiveDb(done())
 
-  done(cb)
+  done(function (err) {
+    if (err) return cb(err)
+    // Close archive last to make sure writes from network/file watching are done
+    closeArchiveDb(cb)
+  })
 
   function closeArchiveDb (cb) {
     self.archive.close(function (err) {

--- a/lib/import-files.js
+++ b/lib/import-files.js
@@ -1,7 +1,6 @@
 var assert = require('assert')
-var each = require('stream-each')
 var match = require('anymatch')
-var walker = require('folder-walker')
+var countFiles = require('count-files')
 var hyperImport = require('hyperdrive-import-files')
 var debug = require('debug')('dat-node')
 
@@ -13,11 +12,6 @@ function importer (archive, target, opts, cb) {
   if (typeof opts === 'function') return importer(archive, target, {}, opts)
 
   opts = opts || {}
-
-  var countStats = {
-    files: 0,
-    bytes: 0
-  }
 
   // Set default ignore and hidden ignore option
   var defaultIgnore = [/^(?:\/.*)?\.dat(?:\/.*)?$/] // ignore .dat
@@ -34,22 +28,15 @@ function importer (archive, target, opts, cb) {
 
   debug('Importer created. Counting Files.')
   // Start counting the files
-  each(walker(target), countFiles, function (err) {
+  var ignore = function (file) {
+    return match(opts.ignore, file)
+  }
+  var countStats = countFiles(target, {ignore: ignore}, function (err, stats) {
     if (err) cb(err)
-    debug('File count finished')
+    debug('File count finished', countStats)
     importer.emit('count finished', countStats)
   })
   importer.countStats = countStats // TODO: make importer vs count stats clearer
 
   return importer
-
-  function countFiles (data, next) {
-    if (opts.ignore && match(opts.ignore, data.filepath)) return next()
-    if (data.type === 'file') {
-      countStats.files += 1
-      countStats.bytes += data.stat.size
-      importer.emit('file counted')
-    }
-    next()
-  }
 }

--- a/lib/stats.js
+++ b/lib/stats.js
@@ -10,7 +10,7 @@ module.exports = function (archive, db) {
 
   var stats = Stats({
     archive: archive,
-    db: sub(db, `${encoding.toStr(archive.key)}-stats`)
+    db: sub(db, `${encoding.toStr(archive.discoveryKey)}-stats`)
   })
   stats.network = networkSpeed(archive, {timeout: 2000})
 

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
   "license": "MIT",
   "dependencies": {
     "anymatch": "^1.3.0",
+    "count-files": "^2.1.0",
     "dat-encoding": "^4.0.1",
     "debug": "^2.6.0",
-    "folder-walker": "^3.0.0",
     "hyperdiscovery": "^1.0.1",
     "hyperdrive": "^7.9.0",
     "hyperdrive-import-files": "^2.8.0",
@@ -29,7 +29,6 @@
     "level": "^1.5.0",
     "multicb": "^1.2.1",
     "random-access-file": "^1.3.1",
-    "stream-each": "^1.2.0",
     "subleveldown": "^2.1.0",
     "untildify": "^3.0.2"
   },


### PR DESCRIPTION
Working on some bugs for https://github.com/datproject/dat-node/milestone/3

* Close network & file watcher before archive/db #71 
* Use discovery key for subleveldb's (fewer public keys hanging around)
* Improve counting speed (part of #75)


## TODO:

- [x] what happens if import finishes before count? (less worried about this now with much faster counting)
- [ ] save port option to DB #59 