### PR TITLE
Add functions for read/write keys

### DIFF
--- a/dat.js
+++ b/dat.js
@@ -4,6 +4,7 @@ var multicb = require('multicb')
 var importFiles = require('./lib/import-files')
 var createNetwork = require('./lib/network')
 var stats = require('./lib/stats')
+var keys = require('./lib/keys')
 
 module.exports = Dat
 
@@ -102,6 +103,19 @@ Dat.prototype.importFiles = function (target, opts, cb) {
   })
   self.options.importer = self.importer.options
   return self.importer
+}
+
+Dat.prototype.writeKeys = function (dir, cb) {
+  if (typeof dir === 'function') return this.writeKeys(null, dir)
+  if (!dir) dir = path.join(this.path, '.dat')
+  var self = this
+  keys.writeKeys(self.archive, dir, cb)
+}
+
+Dat.prototype.readKeys = function (dir, cb) {
+  if (typeof dir === 'function') return this.readKeys(null, dir)
+  if (!dir) dir = path.join(this.path, '.dat')
+  keys.readKeys(dir, cb)
 }
 
 Dat.prototype.close = function (cb) {

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 var assert = require('assert')
-var fs = require('fs')
 var path = require('path')
 var hyperdrive = require('hyperdrive')
 var untildify = require('untildify')
@@ -27,26 +26,9 @@ function createDat (dirOrDrive, opts, cb) {
   debug('Running initArchive on', opts.dir, 'with opts:', opts)
   initArchive(opts, function (err, archive, db) {
     if (err) return cb(err)
+    debug('initArchive callback')
 
     var dat = new Dat(archive, db, opts)
-    writeKeys(function (err) {
-      if (err) return cb(err)
-      debug('initArchive callback')
-      cb(null, dat)
-    })
-
-    function writeKeys (cb) {
-      // TODO: allow option or don't do if temp db?
-      if (!dat.key) return cb() // snapshot
-
-      var basePath = path.join(dat.path, '.dat')
-      var pubKeyPath = path.join(basePath, 'key_ed25519_pub')
-      fs.writeFile(pubKeyPath, dat.key.toString('base64'), function (err) {
-        if (err || !dat.owner) return cb(err)
-        // owner, write secret key
-        var secKeyPath = path.join(basePath, 'key_ed25519')
-        fs.writeFile(secKeyPath, dat.archive.metadata.secretKey.toString('base64'), cb)
-      })
-    }
+    cb(null, dat)
   })
 }

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var assert = require('assert')
-var hyperdrive = require('hyperdrive')
+var fs = require('fs')
 var path = require('path')
+var hyperdrive = require('hyperdrive')
 var untildify = require('untildify')
 var debug = require('debug')('dat-node')
 var initArchive = require('./lib/init-archive')
@@ -26,8 +27,26 @@ function createDat (dirOrDrive, opts, cb) {
   debug('Running initArchive on', opts.dir, 'with opts:', opts)
   initArchive(opts, function (err, archive, db) {
     if (err) return cb(err)
-    debug('initArchive callback')
+
     var dat = new Dat(archive, db, opts)
-    cb(null, dat)
+    writeKeys(function (err) {
+      if (err) return cb(err)
+      debug('initArchive callback')
+      cb(null, dat)
+    })
+
+    function writeKeys (cb) {
+      // TODO: allow option or don't do if temp db?
+      if (!dat.key) return cb() // snapshot
+
+      var basePath = path.join(dat.path, '.dat')
+      var pubKeyPath = path.join(basePath, 'key_ed25519_pub')
+      fs.writeFile(pubKeyPath, dat.key.toString('base64'), function (err) {
+        if (err || !dat.owner) return cb(err)
+        // owner, write secret key
+        var secKeyPath = path.join(basePath, 'key_ed25519')
+        fs.writeFile(secKeyPath, dat.archive.metadata.secretKey.toString('base64'), cb)
+      })
+    }
   })
 }

--- a/lib/keys.js
+++ b/lib/keys.js
@@ -1,0 +1,38 @@
+var assert = require('assert')
+var fs = require('fs')
+var path = require('path')
+
+module.exports = {
+  readKeys: function (dir, cb) {
+    assert.ok(dir, 'lib/keys readKeys dir required')
+    assert.ok(cb, 'lib/keys readKeys cb required')
+    var keys = {}
+    var pubKeyPath = path.join(dir, 'key_ed25519_pub')
+    var secKeyPath = path.join(dir, 'key_ed25519')
+
+    fs.readFile(pubKeyPath, function (err, data) {
+      if (err) return cb(err)
+      keys.public = Buffer.from(data, 'hex')
+      fs.readFile(secKeyPath, function (err, data) {
+        if (err) return cb(err)
+        keys.secret = Buffer.from(data, 'hex')
+        cb(null, keys)
+      })
+    })
+  },
+  writeKeys: function (archive, dir, cb) {
+    assert.ok(archive, 'lib/keys writeKeys archive required')
+    assert.ok(dir, 'lib/keys writeKeys dir required')
+    assert.ok(cb, 'lib/keys writeKeys cb required')
+    if (!archive.key) return cb() // snapshot
+    var pubKeyPath = path.join(dir, 'key_ed25519_pub')
+    var secKeyPath = path.join(dir, 'key_ed25519')
+    fs.writeFile(pubKeyPath, archive.key, function (err) {
+      if (err || !archive.owner) return cb(err)
+      // owner, write secret key for metadata
+      fs.writeFile(secKeyPath, archive.metadata.secretKey, cb)
+
+      // TODO: write content keys?
+    })
+  }
+}

--- a/tests/misc.js
+++ b/tests/misc.js
@@ -267,3 +267,21 @@ test('expose swarm.connected', function (t) {
     })
   })
 })
+
+test('write and read keys', function (t) {
+  rimraf.sync(path.join(shareFolder, '.dat'))
+
+  Dat(shareFolder, function (err, shareDat) {
+    t.error(err, 'dat share err')
+    shareDat.writeKeys(function (err) {
+      t.error(err, 'no write keys err')
+      shareDat.readKeys(function (err, keys) {
+        t.error(err, 'no read keys err')
+        t.ok(keys, 'returned keys')
+        t.same(keys.public, shareDat.key, 'key read matches dat.key')
+        t.same(keys.secret, shareDat.archive.metadata.secretKey, 'key read matches archive secret')
+        t.end()
+      })
+    })
+  })
+})

--- a/tests/misc.js
+++ b/tests/misc.js
@@ -280,7 +280,10 @@ test('write and read keys', function (t) {
         t.ok(keys, 'returned keys')
         t.same(keys.public, shareDat.key, 'key read matches dat.key')
         t.same(keys.secret, shareDat.archive.metadata.secretKey, 'key read matches archive secret')
-        t.end()
+        shareDat.close(function () {
+          rimraf.sync(path.join(shareFolder, '.dat'))
+          t.end()
+        })
       })
     })
   })


### PR DESCRIPTION
This PR adds functions for reading and writing the public *metadata* key. #77 

I still don't quite understand the use cases and the implications (e.g. if we also need to use the secret key for the content). Do we want to enable someone to move the "owner" to a different computer? What other uses for secret keys do we need.

I'm going to keep this PR/bug open but move the issue back to the next milestone.

TODO:

- [ ] resolve question on how to use, if we need content.secretKey
- [ ] document new API functions (`dat.readKeys`, `dat.writeKeys`)
- [ ] write strings to files instead of buffers