### PR TITLE
don't mutate input args

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var assert = require('assert')
 var hyperdrive = require('hyperdrive')
+var xtend = require('xtend')
 var path = require('path')
 var untildify = require('untildify')
 var debug = require('debug')('dat-node')
@@ -11,6 +12,8 @@ module.exports = createDat
 function createDat (dirOrDrive, opts, cb) {
   assert.ok(dirOrDrive, 'directory or drive required')
   if (typeof opts === 'function') return createDat(dirOrDrive, {}, opts)
+
+  opts = xtend(opts)
 
   // Figure out what first arg is
   if (typeof dirOrDrive === 'string') opts.dir = dirOrDrive

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "multicb": "^1.2.1",
     "random-access-file": "^1.3.1",
     "subleveldown": "^2.1.0",
-    "untildify": "^3.0.2"
+    "untildify": "^3.0.2",
+    "xtend": "^4.0.1"
   },
   "devDependencies": {
     "anymatch": "^1.3.0",


### PR DESCRIPTION
When writing `multidat` I noticed the input args were being mutated; this fixes that. Thanks!