### PR TITLE
more explicit handling of keys

### DIFF
--- a/lib/init-archive.js
+++ b/lib/init-archive.js
@@ -104,7 +104,7 @@ module.exports = function (opts, cb) {
       function tryOpen () {
         // Just in case: double check our logic here =)
         assert.ok(!key, 'dat-node: lib/init-archive tryOpen should be called if we opts.key is used')
-        assert.ok(keys.length === 2, 'dat-node: lib/init-archive tryOpen only two values in database')
+        assert.ok(keys.length && keys.length <= 2, `dat-node: lib/init-archive tryOpen 1-2 values in database, db has ${keys.length}`)
 
         // Existing Keys, No key Option
         // Guess which key is metadata

--- a/lib/init-archive.js
+++ b/lib/init-archive.js
@@ -8,15 +8,15 @@ var encoding = require('dat-encoding')
 var debug = require('debug')('dat-node')
 
 module.exports = function (opts, cb) {
-  assert.ok(opts, 'lib/init-archive opts required')
-  assert.ok(opts.dir, 'dir option required')
-  assert.ok(typeof cb === 'function', 'lib/init-archive callback function required')
+  assert.ok(opts, 'dat-node: lib/init-archive opts required')
+  assert.ok(opts.dir, 'dat-node: lib/init-archive dir option required')
+  assert.ok(typeof cb === 'function', 'dat-node: lib/init-archive callback function required')
 
   var archive
   var drive
   var db
   var dir = opts.dir
-  var key = opts.key ? encoding.toBuf(opts.key) : null
+  var key = opts.key ? encoding.toStr(opts.key) : null
   var dbPath = opts.dbPath || path.join(dir, '.dat')
   var createIfMissing = opts.createIfMissing === false ? opts.createIfMissing : true
   var errorIfExists = opts.errorIfExists || false
@@ -61,55 +61,80 @@ module.exports = function (opts, cb) {
   function checkDriveKeys () {
     // Try to resume archives if there are keys in the drive
     debug('Reading existing keys in drive')
-    drive.core.list(function (err, vals) {
+    drive.core.list(function (err, keys) {
       if (err) return cb(err)
-      if (vals.length > 2 && !key) return cb(new Error('Drive has multiple archives. Must specify key.'))
-      else if (errorIfExists && vals.length) {
+
+      if (keys.length > 2 && !key) return cb(new Error('Drive has multiple archives. Must specify key.'))
+      else if (errorIfExists && keys.length) {
         return db.close(function () {
           cb(new Error('Existing feeds in database.'))
         })
-      } else if (vals.length && key && vals.indexOf(key) === -1) {
+      }
+
+      keys = keys.map(function (val) {
+        return encoding.toStr(val)
+      })
+      debug(`Drive has ${keys.length} existing keys.`)
+      if (keys.length) {
+        debug('keys:', keys)
+      }
+
+      // Error if opts.key is used and doesn't match anything in database
+      if (keys.length && key && keys.indexOf(key) === -1) {
         return db.close(function () {
           cb(new Error('Existing archive in database does not match key option.'))
         })
-      } else if (!vals.length || key) {
-        if (!vals.length) debug('No existing feeds in drive')
-        if (key) debug('Using key option for archive', key)
-        archive = drive.createArchive(key, opts)
-        if (archive.key) debug('Archive key', archive.key.toString('hex'))
-        archive.resumed = false
-        return doneArchive(vals.length < 2 && key) // do not open if new drive and external key (e.g. downloading)
       }
-      debug(`Drive has ${vals.length} existing keys. Getting archive key.`)
-      debug('keys')
-      debug(vals[0].toString('hex'))
-      debug(vals[1].toString('hex'))
 
-      // Try to guess metadata and maybe fail
-      debug('Making archive with key', vals[vals.length - 1].toString('hex'))
-      archive = drive.createArchive(vals[vals.length - 1], opts)
-      var openTimeout = setTimeout(function () {
-        debug('Timeout Open')
-        tryOtherKey()
-      }, 150)
-      archive.open(function (err) {
-        clearTimeout(openTimeout)
-        if (!err) return doneArchive()
-        var badKey = err && (err.message.indexOf('Unknown message type') > -1 || err.message.indexOf('Key not found in database') > -1)
-        if (err & !badKey) return cb(err)
-        tryOtherKey()
-      })
+      if (key) {
+        debug('Using key option for archive', key)
+        archive = drive.createArchive(key, opts)
+        archive.resumed = (keys.length === 2) // resumed = true if existing archive
+        return doneArchive(keys.length < 2 && key) // do not open if new drive and external key (e.g. downloading)
+      } else if (!keys.length) {
+        // create a new database + archive
+        debug('No existing feeds in drive, creating new archive.')
+        archive = drive.createArchive(null, opts)
+        archive.resumed = false
+        return doneArchive(false) // open archive - no external key so we are making new archive locally
+      }
+      // opts.key = null && keys.length === 2
+      tryOpen()
+
+      function tryOpen () {
+        // Just in case: double check our logic here =)
+        assert.ok(!key, 'dat-node: lib/init-archive tryOpen should be called if we opts.key is used')
+        assert.ok(keys.length === 2, 'dat-node: lib/init-archive tryOpen only two values in database')
+
+        // Existing Keys, No key Option
+        // Guess which key is metadata
+        // If first key fails, use other key
+        debug('Making archive with key', keys[keys.length - 1].toString('hex'))
+        archive = drive.createArchive(keys[keys.length - 1], opts)
+        var openTimeout = setTimeout(function () {
+          debug('Timeout Open')
+          tryOtherKey()
+        }, 150)
+        archive.open(function (err) {
+          clearTimeout(openTimeout)
+          if (!err) return doneArchive()
+          var badKey = err && (err.message.indexOf('Unknown message type') > -1 || err.message.indexOf('Key not found in database') > -1)
+          if (err & !badKey) return cb(err)
+          tryOtherKey()
+        })
+      }
 
       function tryOtherKey () {
         debug('Bad Key. Trying other key.')
-        archive = drive.createArchive(vals[0], opts)
+        archive = drive.createArchive(keys[0], opts)
         doneArchive()
       }
     })
   }
 
   function doneArchive (doNotOpen) {
-    debug('Archive created')
+    debug('Archive initialized')
+    if (archive.key) debug('Archive key', archive.key.toString('hex'))
     // doNotOpen = true if no existing feeds in drive
     // Opening would have to wait for swarm connection
     if (doNotOpen) return cb(null, archive, db)

--- a/tests/misc.js
+++ b/tests/misc.js
@@ -319,7 +319,7 @@ test('create key and open with different key', function (t) {
     dat.close(function (err) {
       t.ifError(err)
       Dat(shareFolder, {key: '6161616161616161616161616161616161616161616161616161616161616161'}, function (err, dat) {
-        t.ok(err, 'has error')
+        t.same(err.message, 'Existing archive in database does not match key option.', 'has error')
         t.end()
       })
     })


### PR DESCRIPTION
* Mostly cosmetic changes to be more explicit in the logic. 
* Also cast keys as strings to [check if they match](https://github.com/datproject/dat-node/compare/key-logic?expand=1#diff-98e4832c20ce3f02021e173f43d0f8a5R83)
* Add some asserts before `tryOpen` to make sure we got it correct.