### PR TITLE
Temporary fixes for some critical replication issues.

### DIFF
--- a/dat.js
+++ b/dat.js
@@ -56,6 +56,8 @@ Dat.prototype.joinNetwork = function (opts) {
   if (this.network) return this.network.join(this.archive.discoveryKey)
   var self = this
 
+  opts = opts || {}
+  if (self.archive.owner) opts.download = false
   var network = self.network = createNetwork(self.archive, opts)
   self.options.network = network.options
 

--- a/lib/init-archive.js
+++ b/lib/init-archive.js
@@ -26,9 +26,9 @@ module.exports = function (opts, cb) {
   if (opts.resume === false) errorIfExists = true
 
   if (!opts.file) {
-    // TODO: do we always want this set?
-    opts.file = function (name, opts) {
-      return raf(path.join(dir, name), opts && typeof opts.length === 'number' && {length: opts.length})
+    // TODO: add opts.length back in so we can shorten files
+    opts.file = function (name) {
+      return raf(path.join(dir, name))
     }
   }
 

--- a/lib/init-archive.js
+++ b/lib/init-archive.js
@@ -146,6 +146,11 @@ module.exports = function (opts, cb) {
     archive.open(function (err) {
       if (err) return cb(err)
       debug('Archive opened')
+      if (archive.owner && !opts.file) {
+        // Remove file option for archive owners (may be causing bugs?)
+        // archive.append() will not work
+        archive.options.file = null
+      }
       cb(null, archive, db)
     })
   }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "dat-encoding": "^4.0.1",
     "debug": "^2.6.0",
     "hyperdiscovery": "^1.0.1",
-    "hyperdrive": "^7.14.2",
+    "hyperdrive": "7.13.2",
     "hyperdrive-import-files": "^2.8.0",
     "hyperdrive-network-speed": "^1.0.1",
     "hyperdrive-stats": "^3.0.0",


### PR DESCRIPTION
### Never download data as owner 

Source files were getting corrupted from bad replication. This ensures we do not ever download data, possibly corrupting the source. This fix should also be covered in hypercore v4.19.4 (which is covered in our dependency range).

### Remove `opts.length` from raf function

We added an `opts.length` to the `raf` function call to fix replication for new files that were shorter than old versions. Unfortunately, because of bad replication we are getting files truncated now. There may also be other bugs related to this, so am removing for now.

### Do not set opts.file for owner 

This may/may not be a bug fix. The do not download should cover this. But we do not use `archive.append` in importer, so do not need the file option

### Pin Hyperdrive

I pinned it to 7.13.2. I'm not sure the recent updates caused the bugs but they may have exposed an old replication bug.