### PR TITLE
add back opts.length and upgrade hypdrive again

### DIFF
--- a/lib/init-archive.js
+++ b/lib/init-archive.js
@@ -27,8 +27,8 @@ module.exports = function (opts, cb) {
 
   if (!opts.file) {
     // TODO: add opts.length back in so we can shorten files
-    opts.file = function (name) {
-      return raf(path.join(dir, name))
+    opts.file = function (name, opts) {
+      return raf(path.join(dir, name), opts.length, opts && typeof opts.length === 'number' && {length: opts.length})
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "dat-encoding": "^4.0.1",
     "debug": "^2.6.0",
     "hyperdiscovery": "^1.0.1",
-    "hyperdrive": "7.13.2",
+    "hyperdrive": "^7.14.2",
     "hyperdrive-import-files": "^2.8.0",
     "hyperdrive-network-speed": "^1.0.1",
     "hyperdrive-stats": "^3.0.0",


### PR DESCRIPTION
Rolls back some temporary changes from #100. 

`opts.length` is safe to pass because of the bug fixed in hypercore. We may still truncate files in weird situations but less worried about it now because truncation will not be the default.

Can get back on latest hyperdrive. It was breaking files before because of the `_selectLatest` code exposing the hypercore bug. 