### PR TITLE
close old archive before opening new

### DIFF
--- a/lib/init-archive.js
+++ b/lib/init-archive.js
@@ -125,9 +125,12 @@ module.exports = function (opts, cb) {
       }
 
       function tryOtherKey () {
-        debug('Bad Key. Trying other key.')
-        archive = drive.createArchive(keys[0], opts)
-        doneArchive()
+        archive.close(function (err) {
+          if (err) debug(err) // Hopefully no error but we just want this thing closed!
+          debug('Bad Key. Trying other key.')
+          archive = drive.createArchive(keys[0], opts)
+          doneArchive()
+        })
       }
     })
   }


### PR DESCRIPTION
Fixes intermittent archive read verification errors on the source. The content was using the wrong key prefix when trying to read. 

Couldn't really figure out what was causing this (something about the bad content feed being used in new archive), but this fixes it for now.