### PR TITLE
handle archive opts better and set file for owner

### DIFF
--- a/lib/init-archive.js
+++ b/lib/init-archive.js
@@ -1,6 +1,7 @@
 var assert = require('assert')
 var fs = require('fs')
 var path = require('path')
+var xtend = require('xtend')
 var level = require('level')
 var hyperdrive = require('hyperdrive')
 var raf = require('random-access-file')
@@ -20,17 +21,15 @@ module.exports = function (opts, cb) {
   var dbPath = opts.dbPath || path.join(dir, '.dat')
   var createIfMissing = opts.createIfMissing === false ? opts.createIfMissing : true
   var errorIfExists = opts.errorIfExists || false
+  var archiveOpts = xtend({
+    file: function (name, opts) {
+      return raf(path.join(dir, name), opts.length, opts && typeof opts.length === 'number' && {length: opts.length})
+    }
+  }, opts)
 
   // opts.resume backwards compat. TODO: Remove in v2
   if (opts.resume) createIfMissing = false
   if (opts.resume === false) errorIfExists = true
-
-  if (!opts.file) {
-    // TODO: add opts.length back in so we can shorten files
-    opts.file = function (name, opts) {
-      return raf(path.join(dir, name), opts.length, opts && typeof opts.length === 'number' && {length: opts.length})
-    }
-  }
 
   if (opts.db || opts.drive) {
     drive = opts.drive || hyperdrive(opts.db)
@@ -88,13 +87,13 @@ module.exports = function (opts, cb) {
 
       if (key) {
         debug('Using key option for archive', key)
-        archive = drive.createArchive(key, opts)
+        archive = drive.createArchive(key, archiveOpts)
         archive.resumed = (keys.length === 2) // resumed = true if existing archive
         return doneArchive(keys.length < 2 && key) // do not open if new drive and external key (e.g. downloading)
       } else if (!keys.length) {
         // create a new database + archive
         debug('No existing feeds in drive, creating new archive.')
-        archive = drive.createArchive(null, opts)
+        archive = drive.createArchive(null, archiveOpts)
         archive.resumed = false
         return doneArchive(false) // open archive - no external key so we are making new archive locally
       }
@@ -110,7 +109,7 @@ module.exports = function (opts, cb) {
         // Guess which key is metadata
         // If first key fails, use other key
         debug('Making archive with key', keys[keys.length - 1].toString('hex'))
-        archive = drive.createArchive(keys[keys.length - 1], opts)
+        archive = drive.createArchive(keys[keys.length - 1], archiveOpts)
         var openTimeout = setTimeout(function () {
           debug('Timeout Open')
           tryOtherKey()
@@ -128,7 +127,7 @@ module.exports = function (opts, cb) {
         archive.close(function (err) {
           if (err) debug(err) // Hopefully no error but we just want this thing closed!
           debug('Bad Key. Trying other key.')
-          archive = drive.createArchive(keys[0], opts)
+          archive = drive.createArchive(keys[0], archiveOpts)
           doneArchive()
         })
       }
@@ -150,9 +149,11 @@ module.exports = function (opts, cb) {
       if (err) return cb(err)
       debug('Archive opened')
       if (archive.owner && !opts.file) {
-        // Remove file option for archive owners (may be causing bugs?)
-        // archive.append() will not work
-        archive.options.file = null
+        // Do not use opts.length for archive owners
+        // May cause source corruption
+        archive.options.file = function (name, opts) {
+          return raf(path.join(dir, name))
+        }
       }
       cb(null, archive, db)
     })


### PR DESCRIPTION
* Make a copy of the opts to pass to `createArchive`. 
* Set `opts.file` instead of setting to `null`. Test coverage showed me that wasn't working =).