### PR TITLE
createIfMissing errors for empty .dat folder, closes #109

### DIFF
--- a/lib/init-archive.js
+++ b/lib/init-archive.js
@@ -19,7 +19,7 @@ module.exports = function (opts, cb) {
   var dir = opts.dir
   var key = opts.key ? encoding.toStr(opts.key) : null
   var dbPath = opts.dbPath || path.join(dir, '.dat')
-  var createIfMissing = opts.createIfMissing === false ? opts.createIfMissing : true
+  var createIfMissing = !(opts.createIfMissing === false)
   var errorIfExists = opts.errorIfExists || false
   var archiveOpts = xtend({
     file: function (name, opts) {
@@ -49,7 +49,10 @@ module.exports = function (opts, cb) {
 
   function createDb () {
     debug('Making/Reading archive database')
-    level(dbPath, function (err, _db) {
+    level(dbPath, {
+      createIfMissing: createIfMissing,
+      errorIfExists: errorIfExists
+    }, function (err, _db) {
       if (err) return cb(err)
       db = _db
       drive = hyperdrive(db)

--- a/test/options.js
+++ b/test/options.js
@@ -109,16 +109,13 @@ test('createIfMissing false', function (t) {
   })
 })
 
-test('createIfMissing false with existing .dat', function (t) {
+test('createIfMissing false with empty .dat', function (t) {
   rimraf.sync(path.join(shareFolder, '.dat'))
   fs.mkdirSync(path.join(shareFolder, '.dat'))
   Dat(shareFolder, {createIfMissing: false}, function (err, dat) {
-    t.error(err, 'no error')
-    t.ok(dat, 'creates dat')
-    dat.close(function () {
-      rimraf.sync(path.join(shareFolder, '.dat'))
-      t.end()
-    })
+    t.ok(err, 'errors')
+    rimraf.sync(path.join(shareFolder, '.dat'))
+    t.end()
   })
 })
 


### PR DESCRIPTION
Previously `createIfMissing` would only check if there was a `.dat` folder. This passes that option to level so it'll error if there is a `.dat` folder but the database is missing.