### PR TITLE
Cleanup import callback issues, closes #108

### DIFF
--- a/dat.js
+++ b/dat.js
@@ -85,24 +85,16 @@ Dat.prototype.trackStats = function (opts) {
 }
 
 Dat.prototype.importFiles = function (target, opts, cb) {
+  if (!this.archive.owner) throw new Error('Must be archive owner to import files.')
   if (typeof target !== 'string') return this.importFiles('', target, opts)
   if (typeof opts === 'function') return this.importFiles(target, {}, opts)
-  if (!this.archive.owner) return cb(new Error('Must be archive owner to import files.'))
 
   var self = this
   target = target && target.length ? target : self.path
   opts = opts || {}
   if (target === self.path && opts.indexing !== false) opts.indexing = true
 
-  self.importer = importFiles(self.archive, target, opts, function (err) {
-    if (err || self.archive.live) return cb(err)
-    // Finalize snapshot
-    self.archive.finalize(function (err) {
-      if (err) return cb(err)
-      // TODO: write snapshot key to file
-      cb(null)
-    })
-  })
+  self.importer = importFiles(self.archive, target, opts, cb)
   self.options.importer = self.importer.options
   return self.importer
 }

--- a/test/download.js
+++ b/test/download.js
@@ -156,9 +156,12 @@ test('download from snapshot', function (t) {
     shareDat = dat
     dat.importFiles(function (err) {
       t.error(err, 'import no error')
-      shareKey = dat.archive.key
-      dat.joinNetwork()
-      download()
+      dat.archive.finalize(function (err) {
+        t.error(err, 'no error')
+        shareKey = dat.archive.key
+        dat.joinNetwork()
+        download()
+      })
     })
   })
 

--- a/test/importing.js
+++ b/test/importing.js
@@ -81,3 +81,18 @@ test('ignore hidden option turned off', function (t) {
     })
   })
 })
+
+test('import with options but no callback', function (t) {
+  Dat(shareFolder, function (err, dat) {
+    t.error(err)
+    var importer = dat.importFiles({ dryRun: true })
+    importer.on('error', function (err) {
+      t.error(err, 'no error')
+    })
+    dat.close(function (err) {
+      t.error(err, 'no err')
+      rimraf.sync(path.join(shareFolder, '.dat'))
+      t.end()
+    })
+  })
+})

--- a/test/share.js
+++ b/test/share.js
@@ -110,13 +110,20 @@ test('share snapshot', function (t) {
     t.error(err, 'share cb without error')
 
     t.ok(!dat.live, 'live false')
-    // TODO: saving mtime breaks this
-    t.skip(fixturesKey, dat.key, 'TODO: key matches snapshot key')
+    dat.importFiles(function (err) {
+      t.error(err, 'no error')
+      dat.archive.finalize(function (err) {
+        t.error(err, 'no error')
 
-    dat.close(cleanFixtures(function () {
-      rimraf.sync(path.join(fixtures, '.dat'))
-      t.end()
-    }))
+        // TODO: saving mtime breaks this
+        t.skip(fixturesKey, dat.key, 'TODO: key matches snapshot key')
+
+        dat.close(cleanFixtures(function () {
+          rimraf.sync(path.join(fixtures, '.dat'))
+          t.end()
+        }))
+      })
+    })
   })
 })
 


### PR DESCRIPTION
Previously, the import callback auto finalized snapshot archives. This was a bit too fancy and would only allow for a single import to snapshot archives.

* Remove too fancy auto finalize
* Do not require callback for import options (will emit errors if callback is null) #108 
* Fix snapshot tests
* Add import without callback test