### PR TITLE
add .datignore to import ignore

### DIFF
--- a/dat.js
+++ b/dat.js
@@ -1,6 +1,7 @@
 var assert = require('assert')
 var path = require('path')
 var multicb = require('multicb')
+var xtend = require('xtend')
 var importFiles = require('./lib/import-files')
 var createNetwork = require('./lib/network')
 var stats = require('./lib/stats')
@@ -91,8 +92,9 @@ Dat.prototype.importFiles = function (target, opts, cb) {
 
   var self = this
   target = target && target.length ? target : self.path
-  opts = opts || {}
-  if (target === self.path && opts.indexing !== false) opts.indexing = true
+  opts = xtend({
+    indexing: opts.indexing || (target === self.path)
+  }, opts)
 
   self.importer = importFiles(self.archive, target, opts, cb)
   self.options.importer = self.importer.options

--- a/lib/import-files.js
+++ b/lib/import-files.js
@@ -1,4 +1,6 @@
 var assert = require('assert')
+var fs = require('fs')
+var path = require('path')
 var match = require('anymatch')
 var countFiles = require('count-files')
 var hyperImport = require('hyperdrive-import-files')
@@ -12,26 +14,30 @@ function importer (archive, target, opts, cb) {
   if (typeof opts === 'function') return importer(archive, target, {}, opts)
 
   opts = opts || {}
-
-  // Set default ignore and hidden ignore option
+  opts.ignore = opts.ignore // we want an array here
+    ? Array.isArray(opts.ignore)
+      ? opts.ignore
+      : [opts.ignore]
+    : []
   var defaultIgnore = [/^(?:\/.*)?\.dat(?:\/.*)?$/] // ignore .dat
-  if (opts.ignoreHidden !== false) defaultIgnore.push(/[/\\]\./) // ignore all hidden things
+  var ignoreHidden = [/[/\\]\./]
+  var datIgnore = !(opts.useDatIgnore === false) ? getDatIgnore(target) : []
 
-  // Update ignore with any opts passed
-  if (!opts.ignore) opts.ignore = defaultIgnore // no opt, use default
-  else if (Array.isArray(opts.ignore)) opts.ignore = opts.ignore.concat(defaultIgnore)
-  else opts.ignore = [opts.ignore].concat(defaultIgnore)
+  // Add ignore options
+  opts.ignore = opts.ignore.concat(defaultIgnore) // always ignore .dat folder
+  if (datIgnore) opts.ignore = opts.ignore.concat(datIgnore) // add .datignore
+  if (opts.ignoreHidden !== false) opts.ignore = opts.ignore.concat(ignoreHidden) // ignore all hidden things
 
   var importer = hyperImport(archive, target, opts, cb)
-
   importer.options = importer.options || opts
 
   debug('Importer created. Counting Files.')
   // Start counting the files
-  var ignore = function (file) {
-    return match(opts.ignore, file)
-  }
-  var countStats = countFiles(target, {ignore: ignore}, function (err, stats) {
+  var countStats = countFiles(target, {
+    ignore: function (file) {
+      return match(opts.ignore, file)
+    }
+  }, function (err, stats) {
     if (err) cb(err)
     debug('File count finished', countStats)
     importer.emit('count finished', countStats)
@@ -39,4 +45,19 @@ function importer (archive, target, opts, cb) {
   importer.countStats = countStats // TODO: make importer vs count stats clearer
 
   return importer
+}
+
+function getDatIgnore (dir) {
+  try {
+    return fs.readFileSync(path.join(dir, '.datignore'), 'utf8')
+      .split('\n')
+      .filter(function (str) {
+        return !!str.trim()
+      })
+      .map(function (line) {
+        return path.join(dir, line) // prepend the dir to each line
+      })
+  } catch (e) {
+    return []
+  }
 }

--- a/readme.md
+++ b/readme.md
@@ -225,19 +225,24 @@ Options include:
 
 ```js
 var opts = {
+  ignoreHidden: true, // ignore hidden files  (if false, .dat will still be ignored)
+  useDatIgnore: true, // ignore entries in the `.datignore` file from import dir target.
+  ignore: // (see below for default info) anymatch expression to ignore files
   watch: false, // watch files for changes & import on change (archive must be live)
   overwrite: true, // allow files in the archive to be overwritten (defaults to true)
   resume: false, // assume the archive isn't fresh
   basePath: '', // where in the archive should the files import to? (defaults to '')
-  ignore: // (see below for default info) anymatch expression to ignore files
   dryRun: false, // step through the import, but don't write any files to the archive (defaults to false)
   indexing: true // Useful if target === dest so hyperdrive does not rewrite the files on import. (defaults to true if target === dest)
+  compareFileContent: false // compare import-candidates to archive's internal copy. If false, will only compare mtime and file-size, which is faster but may reslt in false-positives.
 }
 ```
 
-##### `opts.ignore`
+##### Ignoring Files
 
 `dat-node` provides a default ignore option, ignoring the `.dat` folder and all hidden files or directories. Use `opts.ignoreHidden = false` to import hidden files or folders, except the `.dat` directory.
+
+Additionally, you can use a `.datignore` file to ignore any the user specifies. This is done by default.
 
 *It's important that the `.dat` folder is not imported because it contains a private key that allows the owner to write to the archive.*
 

--- a/test/importing.js
+++ b/test/importing.js
@@ -96,3 +96,7 @@ test('import with options but no callback', function (t) {
     })
   })
 })
+
+test('import with .datignore', function (t) {
+  t.fail('nope')
+})

--- a/test/importing.js
+++ b/test/importing.js
@@ -1,3 +1,4 @@
+var fs = require('fs')
 var path = require('path')
 var test = require('tape')
 var anymatch = require('anymatch')
@@ -98,5 +99,52 @@ test('import with options but no callback', function (t) {
 })
 
 test('import with .datignore', function (t) {
-  t.fail('nope')
+  fs.writeFileSync(path.join(shareFolder, '.datignore'), 'ignoreme.txt')
+  fs.writeFileSync(path.join(shareFolder, 'ignoreme.txt'), 'hello world')
+  Dat(shareFolder, function (err, dat) {
+    t.error(err)
+    var importer = dat.importFiles({dryRun: true}, function (err) {
+      t.error(err)
+      var matchers = dat.options.importer.ignore
+      t.ok(anymatch(matchers, '.dat'), '.dat ignored')
+      t.ok(anymatch(matchers, path.join(shareFolder, 'ignoreme.txt')), 'file in datignore ignored')
+      dat.close(function () {
+        fs.unlinkSync(path.join(shareFolder, '.datignore'))
+        fs.unlinkSync(path.join(shareFolder, 'ignoreme.txt'))
+        rimraf.sync(path.join(shareFolder, '.dat'))
+        t.end()
+      })
+    })
+    importer.on('file imported', function (file) {
+      if (file.path.indexOf('ignoreme.txt') > -1) t.fail('ignored file imported')
+    })
+  })
+})
+
+test('import with opts.useDatIgnore false', function (t) {
+  fs.writeFileSync(path.join(shareFolder, '.datignore'), 'ignoreme.txt')
+  fs.writeFileSync(path.join(shareFolder, 'ignoreme.txt'), 'hello world')
+  Dat(shareFolder, function (err, dat) {
+    t.error(err)
+    var fileImported = false
+    var importer = dat.importFiles({dryRun: true, useDatIgnore: false}, function (err) {
+      t.error(err)
+      var matchers = dat.options.importer.ignore
+      t.ok(anymatch(matchers, '.dat'), '.dat ignored')
+      t.notOk(anymatch(matchers, path.join(shareFolder, 'ignoreme.txt')), 'file in datignore not ignored')
+      dat.close(function () {
+        if (!fileImported) t.fail('file in .datignore not imported')
+        fs.unlinkSync(path.join(shareFolder, '.datignore'))
+        fs.unlinkSync(path.join(shareFolder, 'ignoreme.txt'))
+        rimraf.sync(path.join(shareFolder, '.dat'))
+        t.end()
+      })
+    })
+    importer.on('file imported', function (file) {
+      if (file.path.indexOf('ignoreme.txt') > -1) {
+        fileImported = true
+        t.pass('ignored file imported')
+      }
+    })
+  })
 })


### PR DESCRIPTION
* Adds support for a `.datignore` file, #117 

Notes: the `.datignore` file itself will be ignore right now by default with `opts.ignoreHidden`.

TODO:
* ~Add test(s) for dat ignore file~
* ~Docs docs docs 📖 ~