### PR TITLE
Improved Peer stats

### DIFF
--- a/lib/stats.js
+++ b/lib/stats.js
@@ -13,6 +13,28 @@ module.exports = function (archive, db) {
     db: sub(db, `${encoding.toStr(archive.discoveryKey)}-stats`)
   })
   stats.network = networkSpeed(archive, {timeout: 2000})
+  stats.peers = peers
 
   return stats
+
+  function peers () {
+    if (!archive.content.peers) return // how to handle this?
+    var totalPeers = archive.content.peers.length
+    var activePeers = archive.content.peers.filter(function (peer) {
+      return peer.remoteLength
+    }).length
+    var sendingPeers = archive.content.peers.filter(function (peer) {
+      return peer.downloaded
+    }).length
+    var completePeers = archive.content.peers.filter(function (peer) {
+      return peer.remoteLength === archive.content.blocks
+    }).length
+
+    return {
+      totalPeers: totalPeers,
+      activePeers: activePeers,
+      sendingPeers: sendingPeers,
+      completePeers: completePeers
+    }
+  }
 }

--- a/lib/stats.js
+++ b/lib/stats.js
@@ -18,15 +18,16 @@ module.exports = function (archive, db) {
   return stats
 
   function peers () {
-    if (!archive.content.peers) return // how to handle this?
-    var totalPeers = archive.content.peers.length
-    var activePeers = archive.content.peers.filter(function (peer) {
+    if (!archive.content || !archive.content.peers) return {} // TODO: how to handle this?
+    var peers = archive.content.peers
+    var totalPeers = peers.length
+    var activePeers = peers.filter(function (peer) {
       return peer.remoteLength
     }).length
-    var sendingPeers = archive.content.peers.filter(function (peer) {
+    var sendingPeers = peers.filter(function (peer) {
       return peer.downloaded
     }).length
-    var completePeers = archive.content.peers.filter(function (peer) {
+    var completePeers = peers.filter(function (peer) {
       return peer.remoteLength === archive.content.blocks
     }).length
 

--- a/lib/stats.js
+++ b/lib/stats.js
@@ -13,29 +13,29 @@ module.exports = function (archive, db) {
     db: sub(db, `${encoding.toStr(archive.discoveryKey)}-stats`)
   })
   stats.network = networkSpeed(archive, {timeout: 2000})
-  stats.peers = peers
+
+  Object.defineProperties(stats, {
+    peers: {
+      enumerable: true,
+      get: function () {
+        if (!archive.content || !archive.content.peers) return {} // TODO: how to handle this?
+        var peers = archive.content.peers
+        var total = peers.length
+        var downloadingFrom = peers.filter(function (peer) {
+          return peer.downloaded
+        }).length
+        var complete = peers.filter(function (peer) {
+          return peer.remoteLength === archive.content.blocks
+        }).length
+
+        return {
+          total: total,
+          downloadingFrom: downloadingFrom,
+          complete: complete
+        }
+      }
+    }
+  })
 
   return stats
-
-  function peers () {
-    if (!archive.content || !archive.content.peers) return {} // TODO: how to handle this?
-    var peers = archive.content.peers
-    var totalPeers = peers.length
-    var activePeers = peers.filter(function (peer) {
-      return peer.remoteLength
-    }).length
-    var sendingPeers = peers.filter(function (peer) {
-      return peer.downloaded
-    }).length
-    var completePeers = peers.filter(function (peer) {
-      return peer.remoteLength === archive.content.blocks
-    }).length
-
-    return {
-      totalPeers: totalPeers,
-      activePeers: activePeers,
-      sendingPeers: sendingPeers,
-      completePeers: completePeers
-    }
-  }
 }

--- a/package.json
+++ b/package.json
@@ -37,8 +37,6 @@
     "xtend": "^4.0.1"
   },
   "devDependencies": {
-    "anymatch": "^1.3.0",
-    "dat-encoding": "^3.0.1",
     "dependency-check": "^2.8.0",
     "memdb": "^1.3.1",
     "memdown": "^1.2.4",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "multicb": "^1.2.1",
     "random-access-file": "^1.3.1",
     "subleveldown": "^2.1.0",
+    "temporary-directory": "^1.0.2",
     "untildify": "^3.0.2",
     "xtend": "^4.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "multicb": "^1.2.1",
     "random-access-file": "^1.3.1",
     "subleveldown": "^2.1.0",
-    "temporary-directory": "^1.0.2",
     "untildify": "^3.0.2",
     "xtend": "^4.0.1"
   },
@@ -48,7 +47,8 @@
     "rimraf": "^2.5.4",
     "standard": "^8.6.0",
     "tap-spec": "^4.1.1",
-    "tape": "^4.6.3"
+    "tape": "^4.6.3",
+    "temporary-directory": "^1.0.2"
   },
   "keywords": [
     "data",

--- a/readme.md
+++ b/readme.md
@@ -255,6 +255,12 @@ Additionally, you can use a `.datignore` file to ignore any the user specifies. 
 
 Get upload and download speeds: `stats.network.uploadSpeed` or `stats.network.downloadSpeed`. Transfer speeds are tracked using [hyperdrive-network-speed](https://github.com/joehand/hyperdrive-network-speed/).
 
+##### `var peers = stats.peers`
+
+* `peers.total` - total number of connected peers
+* `peers.complete` - connected peers with all the content data
+* `peers.downloadingFrom` - connected peers the user has downloaded data from
+
 #### `dat.pause()`
 
 Pause all upload & downloads. Currently, this is the same as `dat.leaveNetwork()`, which leaves the network and destroys the swarm. Discovery will happen again on `resume()`.

--- a/test/network.js
+++ b/test/network.js
@@ -167,8 +167,10 @@ test('peer connection information between 3 peers', function (t) {
           var network = clientDat.joinNetwork({dht: false, tcp: false})
           network.once('connection', function () {
             clientDat.archive.open(function () {
-              onConnect(function () {
-                clientDat.archive.content.once('download', onTransfer)
+              process.nextTick(function () {
+                onConnect(function () {
+                  clientDat.archive.content.once('download', onTransfer)
+                })
               })
             })
           })

--- a/test/network.js
+++ b/test/network.js
@@ -41,7 +41,6 @@ test('peer connection information between two peers', function (t) {
     sourceStats = srcDat.trackStats()
     srcDat.importFiles(function () {
       srcDat.joinNetwork()
-      // srcDat.archive.content.once('upload', onTransfer)
     })
 
     function beforeConnect (cb) {
@@ -72,8 +71,6 @@ test('peer connection information between two peers', function (t) {
     function onTransfer () {
       var sPeers = sourceStats.peers()
       var cPeers = clientStats.peers()
-      // console.log(clientStats.get())
-      // console.log(srcDat.archive.content.peers)
       t.ok(sPeers.totalPeers >= 1, 'onTransfer: source has 1 (or more) total peers')
       t.skip(sPeers.activePeers, 1, 'onTransfer: source has 1 active peer') // TODO: this seems 1 block behind, but we only have 1 block.
       t.same(sPeers.sendingPeers, 0, 'onTransfer: source has zero sending peer')
@@ -128,6 +125,146 @@ test('peer connection information between two peers', function (t) {
     function done () {
       dat.close(function () {
         clientClean()
+        t.end()
+      })
+    }
+  })
+})
+
+test('peer connection information between 3 peers', function (t) {
+  var srcDat
+  var clientDat
+  var clientDat1
+  var client1Clean
+  var client2Clean
+
+  Dat(shareFolder, { db: memdb() }, function (err, dat) {
+    srcDat = dat
+    t.error(err, 'no error')
+    var sourceStats
+    var clientStats
+
+    tmp(function (err, dir, cleanup) {
+      if (err) throw err
+      Dat(dir, { key: dat.key }, function (err, dat) {
+        clientDat1 = dat
+        client1Clean = cleanup
+        t.error(err, 'no error')
+        dat.trackStats()
+        dat.joinNetwork()
+      })
+    })
+
+    tmp(function (err, dir, cleanup) {
+      if (err) throw err
+      Dat(dir, { key: dat.key }, function (err, dat) {
+        clientDat = dat
+        client2Clean = cleanup
+        t.error(err, 'no error')
+        clientStats = clientDat.trackStats()
+
+        beforeConnect(function () {
+          var network = clientDat.joinNetwork()
+          network.once('connection', function () {
+            clientDat.archive.open(function () {
+              onConnect(function () {
+                clientDat.archive.content.once('download', onTransfer)
+              })
+            })
+          })
+        })
+      })
+    })
+
+    sourceStats = srcDat.trackStats()
+    srcDat.importFiles(function () {
+      srcDat.joinNetwork()
+    })
+
+    function beforeConnect (cb) {
+      var sPeers = sourceStats.peers()
+      var cPeers = clientStats.peers()
+      t.same(sPeers.totalPeers, 0, 'beforeConnect: source has zero total peers')
+      t.same(sPeers.activePeers, 0, 'beforeConnect: source has zero active peer')
+      t.same(sPeers.sendingPeers, 0, 'beforeConnect: source has zero sending peer')
+      t.same(sPeers.completePeers, 0, 'beforeConnect: source has zero complete peer')
+      t.notOk(cPeers.totalPeers, 'beforeConnect: client totalPeers undefined')
+      cb()
+    }
+
+    function onConnect (cb) {
+      var sPeers = sourceStats.peers()
+      var cPeers = clientStats.peers()
+      t.ok(sPeers.totalPeers >= 1, 'onConnect: source has 1 (or more) total peers')
+      t.same(sPeers.activePeers, 0, 'onConnect: source has zero active peer')
+      t.same(sPeers.sendingPeers, 0, 'onConnect: source has zero sending peer')
+      t.same(sPeers.completePeers, 0, 'onConnect: source has zero complete peer')
+      t.ok(cPeers.totalPeers >= 1, 'onConnect: client has 1 (or more) total peers')
+      t.same(cPeers.activePeers, 0, 'onConnect: client has zero active peer')
+      t.same(cPeers.sendingPeers, 0, 'onConnect: client has zero sending peer')
+      t.ok(cPeers.completePeers >= 1, 'onConnect: client has >=1 complete peer')
+      cb()
+    }
+
+    function onTransfer () {
+      var sPeers = sourceStats.peers()
+      var cPeers = clientStats.peers()
+      t.ok(sPeers.totalPeers >= 1, 'onTransfer: source has 1 (or more) total peers')
+      t.skip(sPeers.activePeers, 2, 'onTransfer: source has 2 active peer') // TODO: this seems 1 block behind, but we only have 1 block.
+      t.same(sPeers.sendingPeers, 0, 'onTransfer: source has zero sending peer')
+      // Could be 1 or 0, t.same(sPeers.completePeers, 0, 'onTransfer: source has zero complete peer')
+      t.ok(cPeers.totalPeers >= 1, 'onTransfer: client has 1 (or more) total peers')
+      t.ok(cPeers.activePeers >= 1, 'onTransfer: client has 1 (or more) active peer')
+      t.same(cPeers.sendingPeers, 1, 'onTransfer: client has 1 sending peer')
+      t.ok(cPeers.completePeers >= 1, 'onTransfer: client has >=1 complete peer')
+
+      // Check for completion
+      var stats = clientStats.get()
+      if (stats.blocksProgress === stats.blocksTotal) return next()
+      clientStats.on('update', function () {
+        var stats = clientStats.get()
+        if (stats.blocksProgress === stats.blocksTotal) return next()
+      })
+
+      function next () {
+        setTimeout(onComplete, 100) // download blocks take some time to clear
+      }
+    }
+
+    function onComplete () {
+      var sPeers = sourceStats.peers()
+      var cPeers = clientStats.peers()
+      t.ok(sPeers.totalPeers >= 1, 'onComplete: source has 1 (or more) total peers')
+      t.same(sPeers.activePeers, 2, 'onComplete: source has 2 active peer')
+      t.same(sPeers.sendingPeers, 0, 'onComplete: source has zero sending peer')
+      t.same(sPeers.completePeers, 2, 'onComplete: source has 2 complete peer')
+      t.ok(cPeers.totalPeers >= 1, 'onComplete: client has 1 (or more) total peers')
+      t.same(cPeers.activePeers, 2, 'onComplete: client has 1 active peer')
+      t.same(cPeers.sendingPeers, 1, 'onComplete: client has 1 sending peer')
+      t.ok(cPeers.completePeers >= 2, 'onComplete: client has >=2 complete peer')
+      onDisconnect()
+    }
+
+    function onDisconnect () {
+      // disconnect peers
+      clientDat1.close()
+      clientDat.close(function () {
+        var sPeers = sourceStats.peers()
+        var cPeers = clientStats.peers()
+        t.same(sPeers.activePeers, 0, 'onDisconnect: source has 0 active peer')
+        t.same(sPeers.sendingPeers, 0, 'onDisconnect: source has zero sending peer')
+        t.same(sPeers.completePeers, 0, 'onDisconnect: source has zero complete peer')
+        t.same(cPeers.activePeers, 0, 'onDisconnect: client has 0 active peer')
+        t.same(cPeers.sendingPeers, 0, 'onDisconnect: client has 0 sending peer')
+        t.same(cPeers.completePeers, 0, 'onDisconnect: client has 0 complete peer')
+        done()
+      })
+    }
+
+    function done () {
+      dat.close(function () {
+        client1Clean()
+        client2Clean()
         t.end()
       })
     }

--- a/test/network.js
+++ b/test/network.js
@@ -239,8 +239,8 @@ test('peer connection information between 3 peers', function (t) {
       t.same(sPeers.sendingPeers, 0, 'onComplete: source has zero sending peer')
       t.same(sPeers.completePeers, 2, 'onComplete: source has 2 complete peer')
       t.ok(cPeers.totalPeers >= 1, 'onComplete: client has 1 (or more) total peers')
-      t.same(cPeers.activePeers, 2, 'onComplete: client has 1 active peer')
-      t.same(cPeers.sendingPeers, 1, 'onComplete: client has 1 sending peer')
+      t.ok(cPeers.activePeers >=  1, 'onComplete: client has 1 active peer')
+      t.ok(cPeers.sendingPeers >=  1, 'onComplete: client has 1 sending peer')
       t.ok(cPeers.completePeers >= 2, 'onComplete: client has >=2 complete peer')
       onDisconnect()
     }

--- a/test/network.js
+++ b/test/network.js
@@ -44,41 +44,35 @@ test('peer connection information between two peers', function (t) {
     })
 
     function beforeConnect (cb) {
-      var sPeers = sourceStats.peers()
-      var cPeers = clientStats.peers()
-      t.same(sPeers.totalPeers, 0, 'beforeConnect: source has zero total peers')
-      t.same(sPeers.activePeers, 0, 'beforeConnect: source has zero active peer')
-      t.same(sPeers.sendingPeers, 0, 'beforeConnect: source has zero sending peer')
-      t.same(sPeers.completePeers, 0, 'beforeConnect: source has zero complete peer')
-      t.notOk(cPeers.totalPeers, 'beforeConnect: client totalPeers undefined')
+      var sPeers = sourceStats.peers
+      var cPeers = clientStats.peers
+      t.same(sPeers.total, 0, 'beforeConnect: source has zero total peers')
+      t.same(sPeers.downloadingFrom, 0, 'beforeConnect: source has zero sending peer')
+      t.same(sPeers.complete, 0, 'beforeConnect: source has zero complete peer')
+      t.notOk(cPeers.total, 'beforeConnect: client total undefined')
       cb()
     }
 
     function onConnect (cb) {
-      var sPeers = sourceStats.peers()
-      var cPeers = clientStats.peers()
-      t.ok(sPeers.totalPeers >= 1, 'onConnect: source has 1 (or more) total peers')
-      t.same(sPeers.activePeers, 0, 'onConnect: source has zero active peer')
-      t.same(sPeers.sendingPeers, 0, 'onConnect: source has zero sending peer')
-      t.same(sPeers.completePeers, 0, 'onConnect: source has zero complete peer')
-      t.ok(cPeers.totalPeers >= 1, 'onConnect: client has 1 (or more) total peers')
-      t.same(cPeers.activePeers, 0, 'onConnect: client has zero active peer')
-      t.same(cPeers.sendingPeers, 0, 'onConnect: client has zero sending peer')
-      t.ok(cPeers.completePeers >= 1, 'onConnect: client has >=1 complete peer')
+      var sPeers = sourceStats.peers
+      var cPeers = clientStats.peers
+      t.ok(sPeers.total >= 1, 'onConnect: source has 1 (or more) total peers')
+      t.same(sPeers.downloadingFrom, 0, 'onConnect: source has zero sending peer')
+      t.same(sPeers.complete, 0, 'onConnect: source has zero complete peer')
+      t.ok(cPeers.total >= 1, 'onConnect: client has 1 (or more) total peers')
+      t.same(cPeers.downloadingFrom, 0, 'onConnect: client has zero sending peer')
+      t.ok(cPeers.complete >= 1, 'onConnect: client has >=1 complete peer')
       cb()
     }
 
     function onTransfer () {
-      var sPeers = sourceStats.peers()
-      var cPeers = clientStats.peers()
-      t.ok(sPeers.totalPeers >= 1, 'onTransfer: source has 1 (or more) total peers')
-      t.skip(sPeers.activePeers, 1, 'onTransfer: source has 1 active peer') // TODO: this seems 1 block behind, but we only have 1 block.
-      t.same(sPeers.sendingPeers, 0, 'onTransfer: source has zero sending peer')
-      t.same(sPeers.completePeers, 0, 'onTransfer: source has zero complete peer')
-      t.ok(cPeers.totalPeers >= 1, 'onTransfer: client has 1 (or more) total peers')
-      t.same(cPeers.activePeers, 1, 'onTransfer: client has 1 active peer')
-      t.same(cPeers.sendingPeers, 1, 'onTransfer: client has 1 sending peer')
-      t.ok(cPeers.completePeers >= 1, 'onTransfer: client has >=1 complete peer')
+      var sPeers = sourceStats.peers
+      var cPeers = clientStats.peers
+      t.ok(sPeers.total >= 1, 'onTransfer: source has 1 (or more) total peers')
+      t.same(sPeers.downloadingFrom, 0, 'onTransfer: source has zero sending peer')
+      t.ok(cPeers.total >= 1, 'onTransfer: client has 1 (or more) total peers')
+      t.same(cPeers.downloadingFrom, 1, 'onTransfer: client has 1 sending peer')
+      t.ok(cPeers.complete >= 1, 'onTransfer: client has >=1 complete peer')
 
       // Check for completion
       var stats = clientStats.get()
@@ -94,30 +88,26 @@ test('peer connection information between two peers', function (t) {
     }
 
     function onComplete () {
-      var sPeers = sourceStats.peers()
-      var cPeers = clientStats.peers()
-      t.ok(sPeers.totalPeers >= 1, 'onComplete: source has 1 (or more) total peers')
-      t.same(sPeers.activePeers, 1, 'onComplete: source has 1 active peer')
-      t.same(sPeers.sendingPeers, 0, 'onComplete: source has zero sending peer')
-      t.same(sPeers.completePeers, 1, 'onComplete: source has 1 complete peer')
-      t.ok(cPeers.totalPeers >= 1, 'onComplete: client has 1 (or more) total peers')
-      t.same(cPeers.activePeers, 1, 'onComplete: client has 1 active peer')
-      t.same(cPeers.sendingPeers, 1, 'onComplete: client has 1 sending peer')
-      t.ok(cPeers.completePeers >= 1, 'onComplete: client has >=1 complete peer')
+      var sPeers = sourceStats.peers
+      var cPeers = clientStats.peers
+      t.ok(sPeers.total >= 1, 'onComplete: source has 1 (or more) total peers')
+      t.same(sPeers.downloadingFrom, 0, 'onComplete: source has zero sending peer')
+      t.same(sPeers.complete, 1, 'onComplete: source has 1 complete peer')
+      t.ok(cPeers.total >= 1, 'onComplete: client has 1 (or more) total peers')
+      t.same(cPeers.downloadingFrom, 1, 'onComplete: client has 1 sending peer')
+      t.ok(cPeers.complete >= 1, 'onComplete: client has >=1 complete peer')
       onDisconnect()
     }
 
     function onDisconnect () {
       // disconnect peers
       clientDat.close(function () {
-        var sPeers = sourceStats.peers()
-        var cPeers = clientStats.peers()
-        t.same(sPeers.activePeers, 0, 'onDisconnect: source has 0 active peer')
-        t.same(sPeers.sendingPeers, 0, 'onDisconnect: source has zero sending peer')
-        t.same(sPeers.completePeers, 0, 'onDisconnect: source has zero complete peer')
-        t.same(cPeers.activePeers, 0, 'onDisconnect: client has 0 active peer')
-        t.same(cPeers.sendingPeers, 0, 'onDisconnect: client has 0 sending peer')
-        t.same(cPeers.completePeers, 0, 'onDisconnect: client has 0 complete peer')
+        var sPeers = sourceStats.peers
+        var cPeers = clientStats.peers
+        t.same(sPeers.downloadingFrom, 0, 'onDisconnect: source has zero sending peer')
+        t.same(sPeers.complete, 0, 'onDisconnect: source has zero complete peer')
+        t.same(cPeers.downloadingFrom, 0, 'onDisconnect: client has 0 sending peer')
+        t.same(cPeers.complete, 0, 'onDisconnect: client has 0 complete peer')
         done()
       })
     }
@@ -184,41 +174,35 @@ test('peer connection information between 3 peers', function (t) {
     })
 
     function beforeConnect (cb) {
-      var sPeers = sourceStats.peers()
-      var cPeers = clientStats.peers()
-      t.same(sPeers.totalPeers, 0, 'beforeConnect: source has zero total peers')
-      t.same(sPeers.activePeers, 0, 'beforeConnect: source has zero active peer')
-      t.same(sPeers.sendingPeers, 0, 'beforeConnect: source has zero sending peer')
-      t.same(sPeers.completePeers, 0, 'beforeConnect: source has zero complete peer')
-      t.notOk(cPeers.totalPeers, 'beforeConnect: client totalPeers undefined')
+      var sPeers = sourceStats.peers
+      var cPeers = clientStats.peers
+      t.same(sPeers.total, 0, 'beforeConnect: source has zero total peers')
+      t.same(sPeers.downloadingFrom, 0, 'beforeConnect: source has zero sending peer')
+      t.same(sPeers.complete, 0, 'beforeConnect: source has zero complete peer')
+      t.notOk(cPeers.total, 'beforeConnect: client total undefined')
       cb()
     }
 
     function onConnect (cb) {
-      var sPeers = sourceStats.peers()
-      var cPeers = clientStats.peers()
-      t.ok(sPeers.totalPeers >= 1, 'onConnect: source has 1 (or more) total peers')
-      t.same(sPeers.activePeers, 0, 'onConnect: source has zero active peer')
-      t.same(sPeers.sendingPeers, 0, 'onConnect: source has zero sending peer')
-      t.same(sPeers.completePeers, 0, 'onConnect: source has zero complete peer')
-      t.ok(cPeers.totalPeers >= 1, 'onConnect: client has 1 (or more) total peers')
-      t.same(cPeers.activePeers, 0, 'onConnect: client has zero active peer')
-      t.same(cPeers.sendingPeers, 0, 'onConnect: client has zero sending peer')
-      t.ok(cPeers.completePeers >= 1, 'onConnect: client has >=1 complete peer')
+      var sPeers = sourceStats.peers
+      var cPeers = clientStats.peers
+      t.ok(sPeers.total >= 1, 'onConnect: source has 1 (or more) total peers')
+      t.same(sPeers.downloadingFrom, 0, 'onConnect: source has zero sending peer')
+      t.same(sPeers.complete, 0, 'onConnect: source has zero complete peer')
+      t.ok(cPeers.total >= 1, 'onConnect: client has 1 (or more) total peers')
+      t.same(cPeers.downloadingFrom, 0, 'onConnect: client has zero sending peer')
+      t.ok(cPeers.complete >= 1, 'onConnect: client has >=1 complete peer')
       cb()
     }
 
     function onTransfer () {
-      var sPeers = sourceStats.peers()
-      var cPeers = clientStats.peers()
-      t.ok(sPeers.totalPeers >= 1, 'onTransfer: source has 1 (or more) total peers')
-      t.skip(sPeers.activePeers, 2, 'onTransfer: source has 2 active peer') // TODO: this seems 1 block behind, but we only have 1 block.
-      t.same(sPeers.sendingPeers, 0, 'onTransfer: source has zero sending peer')
-      // Could be 1 or 0, t.same(sPeers.completePeers, 0, 'onTransfer: source has zero complete peer')
-      t.ok(cPeers.totalPeers >= 1, 'onTransfer: client has 1 (or more) total peers')
-      t.ok(cPeers.activePeers >= 1, 'onTransfer: client has 1 (or more) active peer')
-      t.same(cPeers.sendingPeers, 1, 'onTransfer: client has 1 sending peer')
-      t.ok(cPeers.completePeers >= 1, 'onTransfer: client has >=1 complete peer')
+      var sPeers = sourceStats.peers
+      var cPeers = clientStats.peers
+      t.ok(sPeers.total >= 1, 'onTransfer: source has 1 (or more) total peers')
+      t.same(sPeers.downloadingFrom, 0, 'onTransfer: source has zero sending peer')
+      t.ok(cPeers.total >= 1, 'onTransfer: client has 1 (or more) total peers')
+      t.same(cPeers.downloadingFrom, 1, 'onTransfer: client has 1 sending peer')
+      t.ok(cPeers.complete >= 1, 'onTransfer: client has >=1 complete peer')
 
       // Check for completion
       var stats = clientStats.get()
@@ -234,16 +218,14 @@ test('peer connection information between 3 peers', function (t) {
     }
 
     function onComplete () {
-      var sPeers = sourceStats.peers()
-      var cPeers = clientStats.peers()
-      t.ok(sPeers.totalPeers >= 1, 'onComplete: source has 1 (or more) total peers')
-      t.same(sPeers.activePeers, 2, 'onComplete: source has 2 active peer')
-      t.same(sPeers.sendingPeers, 0, 'onComplete: source has zero sending peer')
-      t.same(sPeers.completePeers, 2, 'onComplete: source has 2 complete peer')
-      t.ok(cPeers.totalPeers >= 1, 'onComplete: client has 1 (or more) total peers')
-      t.ok(cPeers.activePeers >= 1, 'onComplete: client has 1 active peer')
-      t.ok(cPeers.sendingPeers >= 1, 'onComplete: client has 1 sending peer')
-      t.ok(cPeers.completePeers >= 1, 'onComplete: client has >=1 complete peer')
+      var sPeers = sourceStats.peers
+      var cPeers = clientStats.peers
+      t.ok(sPeers.total >= 1, 'onComplete: source has 1 (or more) total peers')
+      t.same(sPeers.downloadingFrom, 0, 'onComplete: source has zero sending peer')
+      t.same(sPeers.complete, 2, 'onComplete: source has 2 complete peer')
+      t.ok(cPeers.total >= 1, 'onComplete: client has 1 (or more) total peers')
+      t.ok(cPeers.downloadingFrom >= 1, 'onComplete: client has 1 sending peer')
+      t.ok(cPeers.complete >= 1, 'onComplete: client has >=1 complete peer')
       onDisconnect()
     }
 
@@ -251,14 +233,12 @@ test('peer connection information between 3 peers', function (t) {
       // disconnect peers
       clientDat1.close()
       clientDat.close(function () {
-        var sPeers = sourceStats.peers()
-        var cPeers = clientStats.peers()
-        t.same(sPeers.activePeers, 0, 'onDisconnect: source has 0 active peer')
-        t.same(sPeers.sendingPeers, 0, 'onDisconnect: source has zero sending peer')
-        t.same(sPeers.completePeers, 0, 'onDisconnect: source has zero complete peer')
-        t.same(cPeers.activePeers, 0, 'onDisconnect: client has 0 active peer')
-        t.same(cPeers.sendingPeers, 0, 'onDisconnect: client has 0 sending peer')
-        t.same(cPeers.completePeers, 0, 'onDisconnect: client has 0 complete peer')
+        var sPeers = sourceStats.peers
+        var cPeers = clientStats.peers
+        t.same(sPeers.downloadingFrom, 0, 'onDisconnect: source has zero sending peer')
+        t.same(sPeers.complete, 0, 'onDisconnect: source has zero complete peer')
+        t.same(cPeers.downloadingFrom, 0, 'onDisconnect: client has 0 sending peer')
+        t.same(cPeers.complete, 0, 'onDisconnect: client has 0 complete peer')
         done()
       })
     }

--- a/test/network.js
+++ b/test/network.js
@@ -1,0 +1,65 @@
+var fs = require('fs')
+var os = require('os')
+var path = require('path')
+var test = require('tape')
+var rimraf = require('rimraf')
+var memdb = require('memdb')
+var mkdirp = require('mkdirp')
+var tmp = require('temporary-directory')
+
+var Dat = require('..')
+var shareFolder = path.join(__dirname, 'fixtures')
+
+test('peer connection information between two peers', function (t) {
+  Dat(shareFolder, { db: memdb() }, function (err, dat) {
+    tmp(function (err, dir, cleanup) {
+      Dat(dir, { key: dat.key }, function (err, dat) {
+        var network = dat.joinNetwork()
+        var stats = dat.trackStats()
+        dat.archive.open(function () {
+          dat.archive.content.once('download', function () {
+            var peers = stats.peers()
+            console.log('client conn', peers)
+            console.log('net con', network.connected)
+            t.ok(peers.totalPeers >= 0, 'client has total peers') // value is inconsistent
+            t.same(peers.activePeers, 1, 'client has one active peer')
+            t.same(peers.sendingPeers, 1, 'client has one sending peer')
+            t.same(peers.completePeers, 1, 'client has one complete peer')
+          })
+          dat.archive.content.once('download-finished', function () {
+            dat.close(function (err) {
+              t.error(err)
+              process.nextTick(done)
+            })
+          })
+        })
+      })
+    })
+
+    dat.importFiles()
+    var stats = dat.trackStats()
+    var network = dat.joinNetwork()
+    dat.archive.content.once('upload', function () {
+      process.nextTick(function () {
+        var peers = stats.peers()
+        console.log('source connection', peers)
+        t.ok(peers.totalPeers >= 0, 'source has total peers') // value is inconsistent
+        t.same(peers.activePeers, 1, 'source has one active peer')
+        t.same(peers.sendingPeers, 0, 'source has zero sending peer')
+        t.ok(peers.completePeers, 0, 'source has zero complete peer')
+      })
+    })
+
+    function done () {
+      // after other peer has disconnected
+      dat.close(function (err) {
+        t.error(err, 'err')
+        var peers = stats.peers()
+        console.log('done', peers)
+        t.same(peers.activePeers, 0, 'source has zero active peer')
+        t.same(peers.completePeers, 0, 'source has zero complete peer')
+        t.end()
+      })
+    }
+  })
+})

--- a/test/network.js
+++ b/test/network.js
@@ -229,7 +229,7 @@ test('peer connection information between 3 peers', function (t) {
       })
 
       function next () {
-        setTimeout(onComplete, 100) // download blocks take some time to clear
+        setTimeout(onComplete, 200) // download blocks take some time to clear
       }
     }
 
@@ -243,7 +243,7 @@ test('peer connection information between 3 peers', function (t) {
       t.ok(cPeers.totalPeers >= 1, 'onComplete: client has 1 (or more) total peers')
       t.ok(cPeers.activePeers >= 1, 'onComplete: client has 1 active peer')
       t.ok(cPeers.sendingPeers >= 1, 'onComplete: client has 1 sending peer')
-      t.ok(cPeers.completePeers >= 2, 'onComplete: client has >=2 complete peer')
+      t.ok(cPeers.completePeers >= 1, 'onComplete: client has >=1 complete peer')
       onDisconnect()
     }
 

--- a/test/network.js
+++ b/test/network.js
@@ -26,7 +26,7 @@ test('peer connection information between two peers', function (t) {
         clientStats = clientDat.trackStats()
 
         beforeConnect(function () {
-          var network = clientDat.joinNetwork()
+          var network = clientDat.joinNetwork({dht: false, tcp: false})
           network.once('connection', function () {
             clientDat.archive.open(function () {
               onConnect(function () {
@@ -40,7 +40,7 @@ test('peer connection information between two peers', function (t) {
 
     sourceStats = srcDat.trackStats()
     srcDat.importFiles(function () {
-      srcDat.joinNetwork()
+      srcDat.joinNetwork({dht: false, tcp: false})
     })
 
     function beforeConnect (cb) {
@@ -151,7 +151,7 @@ test('peer connection information between 3 peers', function (t) {
         client1Clean = cleanup
         t.error(err, 'no error')
         dat.trackStats()
-        dat.joinNetwork()
+        dat.joinNetwork({dht: false, tcp: false})
       })
     })
 
@@ -164,7 +164,7 @@ test('peer connection information between 3 peers', function (t) {
         clientStats = clientDat.trackStats()
 
         beforeConnect(function () {
-          var network = clientDat.joinNetwork()
+          var network = clientDat.joinNetwork({dht: false, tcp: false})
           network.once('connection', function () {
             clientDat.archive.open(function () {
               onConnect(function () {
@@ -178,7 +178,7 @@ test('peer connection information between 3 peers', function (t) {
 
     sourceStats = srcDat.trackStats()
     srcDat.importFiles(function () {
-      srcDat.joinNetwork()
+      srcDat.joinNetwork({dht: false, tcp: false})
     })
 
     function beforeConnect (cb) {

--- a/test/network.js
+++ b/test/network.js
@@ -239,8 +239,8 @@ test('peer connection information between 3 peers', function (t) {
       t.same(sPeers.sendingPeers, 0, 'onComplete: source has zero sending peer')
       t.same(sPeers.completePeers, 2, 'onComplete: source has 2 complete peer')
       t.ok(cPeers.totalPeers >= 1, 'onComplete: client has 1 (or more) total peers')
-      t.ok(cPeers.activePeers >=  1, 'onComplete: client has 1 active peer')
-      t.ok(cPeers.sendingPeers >=  1, 'onComplete: client has 1 sending peer')
+      t.ok(cPeers.activePeers >= 1, 'onComplete: client has 1 active peer')
+      t.ok(cPeers.sendingPeers >= 1, 'onComplete: client has 1 sending peer')
       t.ok(cPeers.completePeers >= 2, 'onComplete: client has >=2 complete peer')
       onDisconnect()
     }


### PR DESCRIPTION
Adds a method to the stats that exposes clearer peer information.

EDIT: API Changed:


##### `var peers = stats.peers`

* `peers.total` - total number of connected peers
* `peers.complete` - connected peers with all the content data
* `peers.downloadingFrom` - connected peers the user has downloaded data from


---
Old stuff

```js
var stats = dat.trackStats()
var peers = stats.peers()
peers.totalPeers // total peers, from archive.content.peers
peers.activePeers // peers that have data (peer.remoteLength > 0)
peers.sendingPeers // peers that have sent data to user (peer.downloaded > 0)
peers.completePeers // peers that have the complete content feed (peer.remoteLength === archive.content.blocks)
```

This is only for **current connections**, it does not keep a cache once a peer goes offline.

| All connections | Some Content Data Downloaded           | All Content Data Downloaded |
| ------------- |-------------| -----|
| `peers.totalPeers`     | `peers.activePeers` | `peers.completedPeers` |

TODO:
- [x] tests
- [x] test with more than two peers
- [x] fix travis tests (fine locally and can't really figure out why travis is failing right now)
- [x] docs