### PR TITLE
WIP: add pause/resume and improve network join/leave

### DIFF
--- a/dat.js
+++ b/dat.js
@@ -92,12 +92,12 @@ Dat.prototype.joinNetwork = function (opts, cb) {
 }
 
 Dat.prototype.leave =
-Dat.prototype.leaveNetwork = function () {
+Dat.prototype.leaveNetwork = function (cb) {
   if (!this.network) return
   debug('leaveNetwork()')
   this.archive.unreplicate()
   this.network.leave(this.archive.discoveryKey)
-  this.network.destroy()
+  this.network.destroy(cb)
   delete this.network
 }
 
@@ -167,7 +167,7 @@ Dat.prototype.close = function (cb) {
 
   function closeNet (cb) {
     if (!self.network) return cb()
-    self.network.close(cb)
+    self.leave(cb)
   }
 
   function closeFileWatch (cb) {

--- a/dat.js
+++ b/dat.js
@@ -147,10 +147,7 @@ Dat.prototype.close = function (cb) {
   closeFileWatch(done())
   closeArchiveDb(done())
 
-  done(function (err) {
-    if (err) return cb(err)
-    cb()
-  })
+  done(cb)
 
   function closeArchiveDb (cb) {
     self.archive.close(function (err) {

--- a/readme.md
+++ b/readme.md
@@ -255,6 +255,14 @@ Additionally, you can use a `.datignore` file to ignore any the user specifies. 
 
 Get upload and download speeds: `stats.network.uploadSpeed` or `stats.network.downloadSpeed`. Transfer speeds are tracked using [hyperdrive-network-speed](https://github.com/joehand/hyperdrive-network-speed/).
 
+#### `dat.pause()`
+
+Pause all upload & downloads. Currently, this is the same as `dat.leaveNetwork()`, which leaves the network and destroys the swarm. Discovery will happen again on `resume()`.
+
+#### `dat.resume()`
+
+Resume network activity. Current, this is the same as `dat.joinNetwork()`.
+
 #### `dat.close(cb)`
 
 Stops replication and closes all the things opened for dat-node, including:

--- a/test/download.js
+++ b/test/download.js
@@ -192,7 +192,6 @@ test('Download pause', function (t) {
       t.error(err, 'no download init error')
 
       var paused = false
-      var stats = dat.trackStats()
       dat.joinNetwork({ dht: false }).once('connection', function () {
         dat.pause()
         paused = true
@@ -210,9 +209,8 @@ test('Download pause', function (t) {
         }
       })
 
-      stats.on('update', function () {
-        var st = stats.get()
-        if (st.blocksTotal === st.blocksProgress) return done()
+      dat.archive.open(function () {
+        dat.archive.content.on('download-finished', done)
       })
 
       function done () {

--- a/test/download.js
+++ b/test/download.js
@@ -297,20 +297,16 @@ test('download from snapshot', function (t) {
 
             dat.close(function () {
               t.pass('close callback ok')
-              t.end()
+              snapshotDat.close(function () {
+                rimraf.sync(path.join(fixtures, '.dat'))
+                t.end()
+              })
             })
           })
         }
       })
     })
   }
-})
-
-test('finished', function (t) {
-  shareDat.close(function () {
-    rimraf.sync(path.join(fixtures, '.dat'))
-    t.end()
-  })
 })
 
 test.onFinish(function () {

--- a/test/download.js
+++ b/test/download.js
@@ -217,7 +217,9 @@ test('Download pause', function (t) {
 
       function done () {
         t.pass('finished download after resume')
-        dat.close(function () {
+        if (dat._closed) return
+        dat.close(function (err) {
+          t.error(err, 'no error')
           t.end()
         })
       }
@@ -243,7 +245,6 @@ test('download joinNetwork callback without connections', function (t) {
         t.same(dat.network.connected, 0, 'no connections')
         dat.close(function (err) {
           t.error(err, 'no error')
-          console.log('callback end')
           t.end()
         })
       })
@@ -300,7 +301,6 @@ test('download from snapshot', function (t) {
               t.pass('close callback ok')
               snapshotDat.close(function () {
                 rimraf.sync(path.join(fixtures, '.dat'))
-                console.log('snapshot end')
                 t.end()
               })
             })

--- a/test/download.js
+++ b/test/download.js
@@ -252,9 +252,10 @@ test('download joinNetwork callback without connections', function (t) {
 
 test('download from snapshot', function (t) {
   var shareKey
+  var snapshotDat
   Dat(fixtures, {live: false}, function (err, dat) {
     t.error(err, 'live: false share, no error')
-    shareDat = dat
+    snapshotDat = dat
     dat.importFiles(function (err) {
       t.error(err, 'import no error')
       dat.archive.finalize(function (err) {

--- a/test/download.js
+++ b/test/download.js
@@ -307,10 +307,8 @@ test('download from snapshot', function (t) {
 
 test('finished', function (t) {
   shareDat.close(function () {
-    shareDat.db.close(function () {
-      rimraf.sync(path.join(fixtures, '.dat'))
-      t.end()
-    })
+    rimraf.sync(path.join(fixtures, '.dat'))
+    t.end()
   })
 })
 

--- a/test/download.js
+++ b/test/download.js
@@ -236,13 +236,14 @@ test('close first test', function (t) {
 
 test('download joinNetwork callback without connections', function (t) {
   testFolder(function () {
-    Dat(downloadDir, function (err, dat) {
+    Dat(downloadDir, {db: memdb()}, function (err, dat) {
       t.error(err, 'no error')
       dat.joinNetwork(function () {
         t.pass('joinNetwork callback')
         t.same(dat.network.connected, 0, 'no connections')
         dat.close(function (err) {
           t.error(err, 'no error')
+          console.log('callback end')
           t.end()
         })
       })
@@ -299,6 +300,7 @@ test('download from snapshot', function (t) {
               t.pass('close callback ok')
               snapshotDat.close(function () {
                 rimraf.sync(path.join(fixtures, '.dat'))
+                console.log('snapshot end')
                 t.end()
               })
             })


### PR DESCRIPTION
Adds `dat.pause()` and `dat.resume()`, #69 . Right now this is just a alias for `join` and `leave`. Tried to use unprioritize but was having some issues with how hyperdrive forces downloads right now.

Also fix some bugs in the `join` * `leave` code. This makes the leave a bit more strict including destroying the swarm. There were still some messages getting through (protocol bug?) if I only left the swarm on the key, this may have been from duplicate connections.