### PR TITLE
use dat-swarm-defaults

### DIFF
--- a/lib/network.js
+++ b/lib/network.js
@@ -1,5 +1,5 @@
 var assert = require('assert')
-var swarmDefaults = require('datland-swarm-defaults')
+var swarmDefaults = require('dat-swarm-defaults')
 var disc = require('discovery-swarm')
 var xtend = require('xtend')
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "count-files": "^2.6.0",
     "dat-encoding": "^4.0.1",
     "dat-ignore": "^1.0.0",
-    "datland-swarm-defaults": "^1.0.2",
+    "dat-swarm-defaults": "^1.0.0",
     "debug": "^2.6.0",
     "discovery-swarm": "^4.3.0",
     "hyperdrive": "^8.0.1",


### PR DESCRIPTION
Use `dat-swarm-defaults` instead of `datland-swarm-defaults`. 