### PR TITLE
use dry run for import progress

### DIFF
--- a/lib/import-files.js
+++ b/lib/import-files.js
@@ -1,7 +1,7 @@
 var assert = require('assert')
-var countFiles = require('count-files')
 var mirror = require('mirror-folder')
 var datIgnore = require('dat-ignore')
+var speed = require('speedometer')
 var xtend = require('xtend')
 // var debug = require('debug')('dat-node')
 
@@ -12,26 +12,45 @@ function importer (archive, src, opts, cb) {
   assert.ok(src, 'lib/import-files src directory required')
   if (typeof opts === 'function') return importer(archive, src, {}, opts)
 
+  var progress
+  var indexSpeed = speed()
   opts = xtend({
     watch: false,
-    dereference: true
-    // TODO: opts.indexing? - how do we support that
-    // TODO: opts for custom equals functions?
+    dereference: true,
+    count: true
   }, opts, {
-    // overwrite opts.ignore (ignore opts are parsed in dat-ignore)
+    // overwrite opts.ignore (original opts.ignore parsed in dat-ignore)
     ignore: datIgnore(src, opts)
   })
 
+  if (opts.count) {
+    // Dry Run Import to get initial import size
+    var importCount = { files: 0, bytes: 0 }
+    var dryRunOpts = xtend(opts, { dryRun: true, watch: false }) // force right side opts
+    var dryRun = mirror(src, {name: '/', fs: archive}, dryRunOpts, function (err) {
+      if (err) return cb(err)
+      progress.emit('count', importCount)
+    })
+    dryRun.on('put', function (src, dst) {
+      if (src.stat.isDirectory()) return
+      importCount.bytes += src.stat.size
+      importCount.files++
+    })
+  }
+
   // Importing
-  var progress = mirror(src, {name: '/', fs: archive}, opts, cb)
-
-  // File Counting
-  progress.count = countFiles(src, opts, function (err, data) {
-    if (err && !cb) return progress.emit('error', err)
-    else if (err) return cb(err)
-    progress.emit('count', data)
+  progress = mirror(src, {name: '/', fs: archive}, opts, cb)
+  progress.on('put-data', function (chunk, src, dst) {
+    progress.indexSpeed = indexSpeed(chunk.length)
   })
-  progress.options = opts
+  if (opts.count) {
+    progress.count = importCount
+    progress.putDone = 0
+    progress.on('put-end', function (src, dst) {
+      progress.putDone++
+    })
+  }
 
+  progress.options = opts
   return progress
 }

--- a/lib/import-files.js
+++ b/lib/import-files.js
@@ -13,6 +13,7 @@ function importer (archive, src, opts, cb) {
   if (typeof opts === 'function') return importer(archive, src, {}, opts)
 
   var progress
+  var importCount
   var indexSpeed = speed()
   opts = xtend({
     watch: false,
@@ -25,7 +26,7 @@ function importer (archive, src, opts, cb) {
 
   if (opts.count) {
     // Dry Run Import to get initial import size
-    var importCount = { files: 0, bytes: 0 }
+    importCount = { files: 0, bytes: 0 }
     var dryRunOpts = xtend(opts, { dryRun: true, watch: false }) // force right side opts
     var dryRun = mirror(src, {name: '/', fs: archive}, dryRunOpts, function (err) {
       if (err) return cb(err)

--- a/lib/import-files.js
+++ b/lib/import-files.js
@@ -46,9 +46,15 @@ function importer (archive, src, opts, cb) {
   })
   if (opts.count) {
     progress.count = importCount
-    progress.putDone = 0
+    progress.putDone = {
+      files: 0,
+      bytes: 0
+    }
     progress.on('put-end', function (src, dst) {
-      if (!src.live) progress.putDone++
+      if (!src.live) {
+        progress.putDone.bytes += src.stat.size
+        progress.putDone.files++
+      }
     })
   }
 

--- a/lib/import-files.js
+++ b/lib/import-files.js
@@ -32,7 +32,7 @@ function importer (archive, src, opts, cb) {
       progress.emit('count', importCount)
     })
     dryRun.on('put', function (src, dst) {
-      if (src.stat.isDirectory()) return
+      if (src.stat.isDirectory() || src.live) return
       importCount.bytes += src.stat.size
       importCount.files++
     })
@@ -47,7 +47,7 @@ function importer (archive, src, opts, cb) {
     progress.count = importCount
     progress.putDone = 0
     progress.on('put-end', function (src, dst) {
-      progress.putDone++
+      if (!src.live) progress.putDone++
     })
   }
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   "author": "Joe Hand <joe@hand.email>",
   "license": "MIT",
   "dependencies": {
-    "count-files": "^2.6.0",
     "dat-encoding": "^4.0.1",
     "dat-ignore": "^1.0.0",
     "dat-swarm-defaults": "^1.0.0",
@@ -27,9 +26,10 @@
     "discovery-swarm": "^4.3.0",
     "hyperdrive": "^9.0.0",
     "hyperdrive-network-speed": "^2.0.0",
-    "mirror-folder": "^2.0.0",
+    "mirror-folder": "github:joehand/mirror-folder#merged",
     "multicb": "^1.2.1",
     "random-access-memory": "^2.3.0",
+    "speedometer": "^1.0.0",
     "untildify": "^3.0.2",
     "xtend": "^4.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "xtend": "^4.0.1"
   },
   "devDependencies": {
+    "count-files": "^2.6.2",
     "dependency-check": "^2.8.0",
     "memdb": "^1.3.1",
     "memdown": "^1.2.4",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "discovery-swarm": "^4.3.0",
     "hyperdrive": "^9.0.0",
     "hyperdrive-network-speed": "^2.0.0",
-    "mirror-folder": "github:joehand/mirror-folder#merged",
+    "mirror-folder": "^2.1.0",
     "multicb": "^1.2.1",
     "random-access-memory": "^2.3.0",
     "speedometer": "^1.0.0",

--- a/readme.md
+++ b/readme.md
@@ -304,7 +304,10 @@ Returns a `importer` object with properties:
 * `importer.on('put-end', src, dest)` - end of file write stream
 * `importer.on('del', dest)` - file deleted from dest
 * `importer.on('end')` - Emits when mirror is done (not emitted in watch mode)
-* `importer.on('count', {files, dirs, bytes})` - Emitted after initial scan of src directory
+* If `opts.count` is true:
+  * `importer.on('count', {files, bytes})` - Emitted after initial scan of src directory. See import progress section for details.
+  * `importer.count` will be `{files, bytes}` to import after initial scan.
+  * `importer.putDone` will track `{files, bytes}` for imported files.
 
 ##### Importer Options
 
@@ -312,6 +315,7 @@ Options include:
 
 ```js
 var opts = {
+  count: true, // do an initial dry run import for rendering progress
   ignoreHidden: true, // ignore hidden files  (if false, .dat will still be ignored)
   useDatIgnore: true, // ignore entries in the `.datignore` file from import dir target.
   ignore: // (see below for default info) anymatch expression to ignore files


### PR DESCRIPTION
Adds some basic progress stats to importer.

* `importer.indexSpeed` - importing speed

New options, `opts.count`, replaces old count stuff with better stats using a dry import run. On startup it will tell you how many files need to be imported. 

* `importer.count.files` is the number of files to be imported on startup
* `importer.putDone` can then be used to see if it is done
