### PR TITLE
Add archive + download stats

### DIFF
--- a/dat.js
+++ b/dat.js
@@ -98,6 +98,9 @@ Dat.prototype.join = function (opts, cb) {
         download: !self.writable && opts.download,
         live: !self.writable && !opts.end
       })
+      stream.on('close', function () {
+        debug('Stream close')
+      })
       stream.on('error', function (err) {
         debug('Replication error:', err.message)
       })

--- a/lib/stats.js
+++ b/lib/stats.js
@@ -13,6 +13,10 @@ module.exports = function (archive) {
     version: 0
   }
   update()
+  if (!archive.writable) {
+    count.downloaded = 0
+    downloadStats()
+  }
 
   // TODO: put in hyperdrive-stats
   stats.get = function () {
@@ -40,6 +44,20 @@ module.exports = function (archive) {
   })
 
   return stats
+
+  function downloadStats () {
+    if (!archive.content) return archive.once('content', downloadStats)
+
+    var feed = state.archive.content
+    count.downloaded = 0
+    for (var i = 0; i < feed.length; i++) {
+      if (feed.has(i)) count.downloaded++
+    }
+
+    archive.content.on('download', function (index, data) {
+      count.downloaded++
+    })
+  }
 
   function update () {
     if (stableVersion()) return wait()

--- a/lib/stats.js
+++ b/lib/stats.js
@@ -1,18 +1,22 @@
 var assert = require('assert')
 // var Stats = require('hyperdrive-stats')
+var each = require('stream-each')
 var networkSpeed = require('hyperdrive-network-speed')
 
 module.exports = function (archive) {
   assert.ok(archive, 'lib/stats archive required')
   var stats = {}
+  var count = {
+    files: 0,
+    byteLength: 0,
+    length: 0,
+    version: 0
+  }
+  update()
 
-  // TODO: hyperdrive-stats
+  // TODO: put in hyperdrive-stats
   stats.get = function () {
-    return {
-      bytesTotal: archive.content.byteLength,
-      blocksTotal: archive.content.length,
-      filesTotal: archive.metadata.length
-    }
+    return count
   }
   stats.network = networkSpeed(archive, {timeout: 500})
 
@@ -23,10 +27,6 @@ module.exports = function (archive) {
         if (!archive.content || !archive.content.peers) return {} // TODO: how to handle this?
         var peers = archive.content.peers
         var total = peers.length
-        // TODO: Not in hypercore v5 yet
-        // var downloadingFrom = peers.filter(function (peer) {
-        //   return peer.downloaded
-        // }).length
         var complete = peers.filter(function (peer) {
           return peer.remoteLength === archive.content.length
         }).length
@@ -40,4 +40,37 @@ module.exports = function (archive) {
   })
 
   return stats
+
+  function update () {
+    if (stableVersion()) return wait()
+
+    // get current size of archive
+    var current = archive.tree.checkout(archive.version)
+    var initial = archive.tree.checkout(count.version)
+    var stream = initial.diff(current, {dels: true, puts: true})
+    each(stream, ondata, wait)
+
+    function ondata (data, next) {
+      if (data.type === 'del') {
+        count.byteLength -= data.value.size
+        count.length -= data.value.blocks
+        count.files--
+      } else {
+        count.byteLength += data.value.size
+        count.length += data.value.blocks
+        count.files++
+      }
+      next()
+    }
+
+    function stableVersion () {
+      if (archive.version < 0) return false
+      return count.version === archive.version
+    }
+
+    function wait () {
+      count.version = archive.version
+      archive.metadata.update(update)
+    }
+  }
 }

--- a/lib/stats.js
+++ b/lib/stats.js
@@ -22,7 +22,7 @@ module.exports = function (archive) {
   stats.get = function () {
     return count
   }
-  stats.network = networkSpeed(archive, {timeout: 500})
+  stats.network = networkSpeed(archive, {timeout: 2000})
 
   Object.defineProperties(stats, {
     peers: {
@@ -54,9 +54,13 @@ module.exports = function (archive) {
       if (feed.has(i)) count.downloaded++
     }
 
-    archive.content.on('download', function (index, data) {
-      count.downloaded++
+    archive.content.on('download', countDown)
+    archive.content.once('syncing', function () {
+      archive.content.removeListener('download', countDown)
     })
+    function countDown (index, data) {
+      count.downloaded++
+    }
   }
 
   function update () {

--- a/lib/stats.js
+++ b/lib/stats.js
@@ -48,7 +48,7 @@ module.exports = function (archive) {
   function downloadStats () {
     if (!archive.content) return archive.once('content', downloadStats)
 
-    var feed = state.archive.content
+    var feed = archive.content
     count.downloaded = 0
     for (var i = 0; i < feed.length; i++) {
       if (feed.has(i)) count.downloaded++

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "multicb": "^1.2.1",
     "random-access-memory": "^2.3.0",
     "speedometer": "^1.0.0",
+    "stream-each": "^1.2.0",
     "untildify": "^3.0.2",
     "xtend": "^4.0.1"
   },


### PR DESCRIPTION
Updates stats API to return the following on `stats.get()`:

```js
{
    version: 0,             // archive.version these stats describe
    files: 0,                  // file count for this version
    byteLength: 0,      // total archive byte size for version
    length: 0,               // number of blocks for the files in this version
    downloaded: 0      // Downloaded blocks 
  }
```

Stats automatically update to latest version when available. 

`downloaded/length` should work for download progress but I need to check with mafintosh if I need to recount on clear (when local blocks are deleted).

cc @juliangruber 
