### PR TITLE
ignore directories by default

### DIFF
--- a/lib/import-files.js
+++ b/lib/import-files.js
@@ -15,13 +15,19 @@ function importer (archive, src, opts, cb) {
   var progress
   var importCount
   var indexSpeed = speed()
+  var ignore = datIgnore(src, opts)
+  var ignoreDirs = !(opts.ignoreDirs === false)
+
   opts = xtend({
     watch: false,
     dereference: true,
     count: true
   }, opts, {
     // overwrite opts.ignore (original opts.ignore parsed in dat-ignore)
-    ignore: datIgnore(src, opts)
+    ignore: function (name, st) {
+      if (ignoreDirs && st && st.isDirectory()) return true
+      return ignore(name, st)
+    }
   })
   debug('importFiles()', opts)
 

--- a/readme.md
+++ b/readme.md
@@ -97,7 +97,7 @@ All dat-node applications have a similar structure around three main elements:
 2. **Network** - connecting to other users to upload or download data.
 3. **Adding Files** - adding files from the file system to the hyperdrive archive.
 
-We'll go through what these are for and a few of the common usages of each element. 
+We'll go through what these are for and a few of the common usages of each element.
 
 ### Storage
 
@@ -317,6 +317,7 @@ Options include:
 var opts = {
   count: true, // do an initial dry run import for rendering progress
   ignoreHidden: true, // ignore hidden files  (if false, .dat will still be ignored)
+  ignoreDirs: true, // do not import directories (hyperdrive does not need them and it pollutes metadata)
   useDatIgnore: true, // ignore entries in the `.datignore` file from import dir target.
   ignore: // (see below for default info) anymatch expression to ignore files
   watch: false, // watch files for changes & import on change (archive must be live)

--- a/test/importing.js
+++ b/test/importing.js
@@ -82,6 +82,29 @@ test('importing: ignore hidden option turned off', function (t) {
   })
 })
 
+test('importing: ignore dirs option turned off', function (t) {
+  Dat(fixtures, {temp: true}, function (err, dat) {
+    t.error(err)
+    dat.importFiles({ ignoreDirs: false }, function () {
+      var stream = dat.archive.history()
+      var hasFolder = false
+      var hasRoot = false
+      stream.on('data', function (data) {
+        if (data.name === '/folder') hasFolder = true
+        if (data.name === '/') hasRoot = true
+      })
+      stream.on('end', function () {
+        t.ok(hasFolder, 'folder in metadata')
+        t.ok(hasRoot, 'root in metadata')
+        dat.close(function () {
+          rimraf.sync(path.join(fixtures, '.dat'))
+          t.end()
+        })
+      })
+    })
+  })
+})
+
 test('importing: import with options but no callback', function (t) {
   Dat(fixtures, {temp: true}, function (err, dat) {
     t.error(err)

--- a/test/share.js
+++ b/test/share.js
@@ -63,9 +63,9 @@ test('share: create dat with default ops', function (t) {
         t.same(st.version, archive.version, 'stats version')
         t.same(st.byteLength, 1452, 'stats bytes')
 
-        t.same(putFiles, 5, 'importer puts')
-        t.same(archive.version, 5, 'archive version')
-        t.same(archive.metadata.length, 6, 'entries in metadata')
+        t.same(putFiles, 3, 'importer puts')
+        t.same(archive.version, 3, 'archive version')
+        t.same(archive.metadata.length, 4, 'entries in metadata')
 
         helpers.verifyFixtures(t, archive, function (err) {
           t.ifError(err)
@@ -96,7 +96,7 @@ test('share: resume with .dat folder', function (t) {
       t.ifError(err, 'count err')
       var archive = dat.archive
 
-      t.same(archive.version, 5, 'archive version still')
+      t.same(archive.version, 3, 'archive version still')
 
       var st = stats.get()
       t.same(st.byteLength, fixtureStats.bytes, 'bytes total still the same')


### PR DESCRIPTION
Re: https://github.com/datproject/dat/issues/741#issuecomment-300489805. We don't need directories in metadata for anything cuz hyperdrive is sweet.

Directories can pollute metadata and can be confusing if mtime changes without a file inside the dat changing (e.g. if it is ignored).

PR adds `opts.ignoreDirs` to import options, default true.
