### PR TITLE
use regular sleep store for not latest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- Change types:
   ### Added, ### Changed, ### Fixed, ### Removed, ### Deprecated
 -->
+### Added
+* Use regular sleep storage if `opts.latest` is false
 
 ## 3.3.0 - 2017-05-10
 ### Added

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -1,5 +1,8 @@
 var fs = require('fs')
+var path = require('path')
 var datStore = require('dat-storage')
+// var secretStorage = require('dat-secret-storage')
+var raf = require('random-access-file')
 var ram = require('random-access-memory')
 
 module.exports = defaultStorage
@@ -19,6 +22,19 @@ function defaultStorage (storage, opts) {
   // Use custom storage or ram
   if (typeof storage !== 'string') return storage
   if (opts.temp) return ram
+  if (opts.latest === false) {
+    // Store as SLEEP files inluding content.data
+    return {
+      metadata: function (name, opts) {
+        // I don't think we want this, we may get multiple 'ogd' sources
+        // if (name === 'secret_key') return secretStorage()(path.join(storage, 'metadata.ogd'), {key: opts.key, discoveryKey: opts.discoveryKey})
+        return raf(path.join(storage, 'metadata.' + name))
+      },
+      content: function (name, opts) {
+        return raf(path.join(storage, 'content.' + name))
+      }
+    }
+  }
 
   try {
     // Store in .dat with secret in ~/.dat

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "hyperdrive-network-speed": "^2.0.0",
     "mirror-folder": "^2.1.0",
     "multicb": "^1.2.1",
+    "random-access-file": "^1.7.2",
     "random-access-memory": "^2.3.0",
     "speedometer": "^1.0.0",
     "stream-each": "^1.2.0",

--- a/readme.md
+++ b/readme.md
@@ -214,7 +214,12 @@ That covers some of the common use cases, let us know if there are more to add! 
 
 Initialize a Dat Archive in `dir`. If there is an existing Dat Archive, the archive will be resumed.
 
-* `storage` is passed to hyperdrive. For example, `storage` count be `require('random-access-file`'). Default storage is still in flux! We'll add more docs here soon.
+#### Storage
+
+* `dir` (Default) - Use [dat-storage](https://github.com/datproject/dat-storage) inside `dir`. This stores files as files, sleep files inside `.dat`, and the secret key in the user's home directory.
+* `dir` with `opts.latest: false` - Store as SLEEP files, including storing the content as a `content.data` file. This is useful for storing all history in a single flat file.
+* `dir` with `opts.temp: true` - Store everything in memory (including files).
+* `storage` function - pass a custom storage function along to hyperdrive, see dat-storage for an example.
 
 Most options are passed directly to the module you're using (e.g. `dat.importFiles(opts)`. However, there are also some initial `opts` can include:
 


### PR DESCRIPTION
Allows using regular sleep storage in a directory by passing `dir` and setting `opts.latest = false`. This will store content as `content.data` folder so we can keep history.