### PR TITLE
add hyperdrive-http support

### DIFF
--- a/dat.js
+++ b/dat.js
@@ -6,6 +6,7 @@ var untildify = require('untildify')
 var importFiles = require('./lib/import-files')
 var createNetwork = require('./lib/network')
 var stats = require('./lib/stats')
+var serveHttp = require('./lib/serve')
 var debug = require('debug')('dat-node')
 
 module.exports = Dat
@@ -184,6 +185,17 @@ Dat.prototype.importFiles = function (src, opts, cb) {
   self.importer = importFiles(self.archive, src, opts, cb)
   self.options.importer = self.importer.options
   return self.importer
+}
+
+/**
+ * Serve archive over http
+ * @type {Function}
+ * @param {Object} [opts] - Options passed to `mirror-folder` and `dat-ignore`
+ * @returns {Object} - node http server instance
+ */
+Dat.prototype.serveHttp = function (opts) {
+  this.server = serveHttp(this.archive, opts)
+  return this.server
 }
 
 /**

--- a/lib/serve.js
+++ b/lib/serve.js
@@ -1,0 +1,22 @@
+var assert = require('assert')
+var http = require('http')
+var serve = require('hyperdrive-http')
+var xtend = require('xtend')
+var debug = require('debug')('dat-node')
+
+module.exports = function (archive, opts) {
+  assert.ok(archive, 'lib/serve: archive required')
+  opts = xtend(opts, {
+    port: 8080,
+    live: true,
+    footer: 'Served via Dat.'
+  })
+
+  var server = http.createServer(serve(archive, opts))
+  server.listen(opts.port)
+  server.on('listening', function () {
+    debug(`http serving on PORT:${opts.port}`)
+  })
+
+  return server
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,6 +79,11 @@
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
       "integrity": "sha1-o+Uvo5FoyCX/V7AkgSbOWo/5VQc="
     },
+    "ap": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/ap/-/ap-0.1.0.tgz",
+      "integrity": "sha1-2KPyZhU3k5ihtTymzBpmag+/4VA="
+    },
     "append-tree": {
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/append-tree/-/append-tree-2.3.5.tgz",
@@ -236,6 +241,11 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/blake2b-wasm/-/blake2b-wasm-1.1.3.tgz",
       "integrity": "sha512-4Wt1zsffEytMMGkRxjs5Ttm2mw+0vJgWnQlE1vdA3RcL8JKddajtnKbXv8yj1Hjciqeu9JMh07gVp77kiHK+Yg=="
+    },
+    "body": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/body/-/body-0.1.0.tgz",
+      "integrity": "sha1-5xT+KM2ISKo0zfLJ8kK74uFdHNg="
     },
     "boom": {
       "version": "2.10.1",
@@ -395,6 +405,11 @@
       "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
       "dev": true
     },
+    "content-types": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/content-types/-/content-types-0.1.0.tgz",
+      "integrity": "sha1-DnkLOr/vkPbst3roWF25CZyvdXg="
+    },
     "core-js": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
@@ -405,6 +420,11 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "corsify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/corsify/-/corsify-2.1.0.tgz",
+      "integrity": "sha1-EaRbxHqzDFTQC7hp6hgC+82aCdA="
     },
     "count-files": {
       "version": "2.6.2",
@@ -553,6 +573,11 @@
           "dev": true
         }
       }
+    },
+    "directory-index-html": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/directory-index-html/-/directory-index-html-2.1.0.tgz",
+      "integrity": "sha1-TVr8UYftumfsarDlX2QioOLLczg="
     },
     "discovery-channel": {
       "version": "5.4.4",
@@ -1198,6 +1223,11 @@
       "integrity": "sha1-AHa59GonBQbduq6lZJaJdGBhKmc=",
       "dev": true
     },
+    "http-methods": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/http-methods/-/http-methods-0.1.0.tgz",
+      "integrity": "sha1-KWkbb8WPT36Bo2BdyoJoKwaORDA="
+    },
     "http-signature": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
@@ -1217,6 +1247,11 @@
       "version": "9.4.5",
       "resolved": "https://registry.npmjs.org/hyperdrive/-/hyperdrive-9.4.5.tgz",
       "integrity": "sha512-gNLe9W1tJFElKJ07HH+U3iWEbkcAptW7xQbb2NO8P1Mm8IAS/QC22MeJaCX8ligFzDTEjfJ4w30IrlA0r5AtBw=="
+    },
+    "hyperdrive-http": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/hyperdrive-http/-/hyperdrive-http-4.2.0.tgz",
+      "integrity": "sha1-NBTHM7g19gd/e+6Np3ilDzSir8M="
     },
     "hyperdrive-network-speed": {
       "version": "2.0.1",
@@ -1438,6 +1473,11 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "iterators": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/iterators/-/iterators-0.1.0.tgz",
+      "integrity": "sha1-0D9mbKTmEwE4VlmXys6lQWQgMVY="
     },
     "jju": {
       "version": "1.3.0",
@@ -1696,6 +1736,11 @@
       "version": "2.3.11",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU="
+    },
+    "mime": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.6.tgz",
+      "integrity": "sha1-WR2E02U6awtKO5343lqoEI5y5eA="
     },
     "mime-db": {
       "version": "1.27.0",
@@ -3300,6 +3345,11 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz",
       "integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg=="
+    },
+    "range-parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
     },
     "re-emitter": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "debug": "^2.6.0",
     "discovery-swarm": "^4.3.0",
     "hyperdrive": "^9.2.9",
+    "hyperdrive-http": "^4.2.0",
     "hyperdrive-network-speed": "^2.0.0",
     "mirror-folder": "^2.1.0",
     "multicb": "^1.2.1",

--- a/readme.md
+++ b/readme.md
@@ -24,6 +24,7 @@ You can start using Dat today in these client applications:
 * Sane defaults and consistent management of storage & secret keys across applications, using [dat-storage](https://github.com/datproject/dat-storage).
 * Easily connect to the Dat network, using [discovery-swarm](https://github.com/mafintosh/discovery-swarm)
 * Import files from the file system, using [mirror-folder](https://github.com/mafintosh/mirror-folder/)
+* Serve dats over http with [hyperdrive-http](https://github.com/joehand/hyperdrive-http)
 * Access APIs to lower level modules with a single `require`!
 
 #### Browser Support
@@ -365,6 +366,19 @@ Get upload and download speeds: `stats.network.uploadSpeed` or `stats.network.do
 
 * `peers.total` - total number of connected peers
 * `peers.complete` - connected peers with all the content data
+
+#### `var server = dat.serveHttp(opts)`
+
+Serve files over http via [hyperdrive-http](https://github.com/joehand/hyperdrive-http). Returns a node http server instance.
+
+```js
+opts = {
+  port: 8080, // http port
+  live: true, // live update directory index listing
+  footer: 'Served via Dat.', // Set a footer for the index listing
+  exposeHeaders: false // expose dat key in headers
+}
+```
 
 #### `dat.pause()`
 


### PR DESCRIPTION
Adds hyperdrive-http support to dat-node baked in. Serve archive over http:

```js
Dat('dir', function (err, dat) {
  dat.serveHttp(opts)
})
```