### PR TITLE
fix progress bar being wrong when deletes / overwrites happen

### DIFF
--- a/lib/stats.js
+++ b/lib/stats.js
@@ -2,10 +2,13 @@ var assert = require('assert')
 var EventEmitter = require('events').EventEmitter
 var each = require('stream-each')
 var networkSpeed = require('hyperdrive-network-speed')
+var bitfield = require('sparse-bitfield')
 
 module.exports = function (archive) {
   assert.ok(archive, 'lib/stats archive required')
   var stats = new EventEmitter()
+  var counted = bitfield()
+
   var count = {
     files: 0,
     byteLength: 0,
@@ -52,17 +55,22 @@ module.exports = function (archive) {
     var feed = archive.content
     count.downloaded = 0
     for (var i = 0; i < feed.length; i++) {
-      if (feed.has(i)) count.downloaded++
+      if (feed.has(i) && counted.set(i, true)) count.downloaded++
     }
     stats.emit('update')
 
     archive.content.on('download', countDown)
-    archive.once('syncing', function () {
-      archive.content.removeListener('download', countDown)
-      downloadStats() // recount after update
-    })
+    archive.content.on('clear', checkDownloaded)
+
+    function checkDownloaded (start, end) {
+      for (; start < end; start++) {
+        if (counted.set(start, false)) count.downloaded--
+      }
+      stats.emit('update')
+    }
+
     function countDown (index, data) {
-      count.downloaded++
+      if (counted.set(index, true)) count.downloaded++
       stats.emit('update')
     }
   }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "multicb": "^1.2.1",
     "random-access-file": "^1.7.2",
     "random-access-memory": "^2.3.0",
+    "sparse-bitfield": "^3.0.3",
     "speedometer": "^1.0.0",
     "stream-each": "^1.2.0",
     "untildify": "^3.0.2",


### PR DESCRIPTION
there is still a rc where it might be >100 for a little bit depending on whether `clear` or the `diff` stream fires first. this fixes the last remaining issues though in general