### PR TITLE
Update readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -342,9 +342,9 @@ You can use a `.datignore` file in the imported directory, `src`, to ignore any 
 
 Emitted when archive stats are updated. Get new stats with `stats.get()`.
 
-##### `var st = stats.get()`
+##### `var st = dat.stats.get()`
 
-Get general archive stats for the latest version:
+`dat.trackStats()` adds a `stats` object to `dat`.  Get general archive stats for the latest version:
 
 ```js
 {


### PR DESCRIPTION
Suggested a change in docs of using the get() method for calling the stats on a dat object. 

I was playing around with this and noticed that `dat.trackStats().get()` did not work because using `dat.trackStats()` added an object `dat.stats` that had the `get()` method. This was not clear to me from the docs.

Note that `dat.trackStats().get().version` kept returning `0`. It got me confused, which is why I suggested this minor change. I recognize that it might be my own fault so feel free to not merge the PR if you judge differently 🥂 