### PR TITLE
catch hyperdrive open errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,9 +97,11 @@ function createDat (dirOrStorage, opts, cb) {
 
     function createArchive () {
       archive = hyperdrive(storage, key, opts)
+      archive.on('error', cb)
       archive.ready(function () {
         debug('archive ready. version:', archive.version)
         if (archive.metadata.has(0) && archive.version) archive.resumed = true
+        archive.removeListener('error', cb)
 
         cb(null, new Dat(archive, opts))
       })


### PR DESCRIPTION
I haven't managed to reproduce this in a test, but in an example where for example the secret keys don't match, this would otherwise emit an uncatchable error.

What do you think, @joehand?