### PR TITLE
Set dat.resume to true for empty archives

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ function createDat (dirOrStorage, opts, cb) {
   var storage = datStore(dirOrStorage, opts)
   var createIfMissing = !(opts.createIfMissing === false)
   var errorIfExists = opts.errorIfExists || false
+  var resuming = false
   opts = xtend({
     // TODO: make sure opts.dir is a directory, not file
     dir: dir,
@@ -63,6 +64,7 @@ function createDat (dirOrStorage, opts, cb) {
     fs.readdir(path.join(opts.dir, '.dat'), function (err, files) {
       // TODO: omg please make this less confusing.
       var noDat = !!(err || !files.length)
+      resuming = !noDat
       var validSleep = (files && files.length && files.indexOf('metadata.key') > -1)
       var badDat = !(noDat || validSleep)
 
@@ -100,7 +102,7 @@ function createDat (dirOrStorage, opts, cb) {
       archive.on('error', cb)
       archive.ready(function () {
         debug('archive ready. version:', archive.version)
-        if (archive.metadata.has(0) && archive.version) archive.resumed = true
+        archive.resumed = resuming
         archive.removeListener('error', cb)
 
         cb(null, new Dat(archive, opts))

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ function createDat (dirOrStorage, opts, cb) {
   var storage = datStore(dirOrStorage, opts)
   var createIfMissing = !(opts.createIfMissing === false)
   var errorIfExists = opts.errorIfExists || false
-  var resuming = false
+  var hasDat = false
   opts = xtend({
     // TODO: make sure opts.dir is a directory, not file
     dir: dir,
@@ -64,7 +64,7 @@ function createDat (dirOrStorage, opts, cb) {
     fs.readdir(path.join(opts.dir, '.dat'), function (err, files) {
       // TODO: omg please make this less confusing.
       var noDat = !!(err || !files.length)
-      resuming = !noDat
+      hasDat = !noDat
       var validSleep = (files && files.length && files.indexOf('metadata.key') > -1)
       var badDat = !(noDat || validSleep)
 
@@ -102,7 +102,11 @@ function createDat (dirOrStorage, opts, cb) {
       archive.on('error', cb)
       archive.ready(function () {
         debug('archive ready. version:', archive.version)
-        archive.resumed = resuming
+        if (hasDat || (archive.metadata.has(0) && archive.version)) {
+          archive.resumed = true
+        } else {
+          archive.resumed = false
+        }
         archive.removeListener('error', cb)
 
         cb(null, new Dat(archive, opts))

--- a/test/share.js
+++ b/test/share.js
@@ -111,6 +111,27 @@ test('share: resume with .dat folder', function (t) {
   })
 })
 
+test('share: resume with empty .dat folder', function (t) {
+  var emptyPath = path.join(__dirname, 'empty')
+  Dat(emptyPath, function (err, dat) {
+    t.error(err, 'cb without error')
+    t.false(dat.resumed, 'resume flag false')
+
+    dat.close(function () {
+      Dat(emptyPath, function (err, dat) {
+        t.error(err, 'cb without error')
+        t.ok(dat.resumed, 'resume flag set')
+
+        dat.close(function () {
+          rimraf(emptyPath, function () {
+            t.end()
+          })
+        })
+      })
+    })
+  })
+})
+
 // TODO: live = false, not implemented yet in hyperdrive v8
 // test('share snapshot', function (t) {
 //   Dat(fixtures, { live: false }, function (err, dat) {

--- a/test/share.js
+++ b/test/share.js
@@ -230,6 +230,7 @@ test('share: cleanup', function (t) {
 test('share: dir storage and opts.temp', function (t) {
   Dat(fixtures, {temp: true}, function (err, dat) {
     t.error(err, 'error')
+    t.false(dat.resumed, 'resume flag false')
 
     dat.importFiles(function (err) {
       t.error(err, 'error')
@@ -248,6 +249,7 @@ test('share: dir storage and opts.temp', function (t) {
 test('share: ram storage & import other dir', function (t) {
   Dat(ram, function (err, dat) {
     t.error(err, 'error')
+    t.false(dat.resumed, 'resume flag false')
 
     dat.importFiles(fixtures, function (err) {
       t.error(err, 'error')


### PR DESCRIPTION
Fixes issue https://github.com/datproject/dat-node/issues/149.

```dat.resume``` now returns true event if the the archive is empty by checking if the ```.dat``` folder exists.
Tests for this feature also included.