### PR TITLE
fix package.json typo

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "debug": "^3.1.0",
     "discovery-swarm": "^5.1.1",
     "hyperdrive": "^9.13.0",
-    "hyperdrive-http": "^4.2.0,
+    "hyperdrive-http": "^4.2.0",
     "hyperdrive-network-speed": "^2.1.0",
     "mirror-folder": "^3.0.0",
     "multicb": "^1.2.1",


### PR DESCRIPTION
The smallest of small prs: this fixes a typo in package.json.