### PR TITLE
Windows related issues caused by random-access-file dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "hyperdrive-http": "^4.4.0",
     "hyperdrive-network-speed": "^2.1.0",
     "mirror-folder": "^3.0.0",
-    "random-access-file": "git+ssh://git@github.com:nharlow89/dat-node.git",
+    "random-access-file": "2.1.0",
     "random-access-memory": "^3.1.1",
     "sparse-bitfield": "^3.0.3",
     "speedometer": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "hyperdrive-http": "^4.4.0",
     "hyperdrive-network-speed": "^2.1.0",
     "mirror-folder": "^3.0.0",
-    "random-access-file": "2.1.0",
+    "random-access-file": "^2.1.2",
     "random-access-memory": "^3.1.1",
     "sparse-bitfield": "^3.0.3",
     "speedometer": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "hyperdrive-http": "^4.4.0",
     "hyperdrive-network-speed": "^2.1.0",
     "mirror-folder": "^3.0.0",
-    "random-access-file": "^2.1.1",
+    "random-access-file": "git+ssh://git@github.com:nharlow89/dat-node.git",
     "random-access-memory": "^3.1.1",
     "sparse-bitfield": "^3.0.3",
     "speedometer": "^1.1.0",


### PR DESCRIPTION
Rolling back to `random-access-file@2.1.0` fixes #238. We can update this dependency once https://github.com/random-access-storage/random-access-file/pull/20 comes through.